### PR TITLE
feat: add optional /loop N support for controlled iterations (v1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — the principle that **constraint + mechanical metric + autonomous iteration = compounding gains**.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
+[![Version](https://img.shields.io/badge/version-1.0.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 
@@ -21,7 +22,7 @@ You set the GOAL → Claude runs the LOOP → You wake up to results
 **The loop:**
 
 ```
-LOOP FOREVER:
+LOOP (FOREVER or N times):
   1. Review current state + git history + results log
   2. Pick the next change (based on what worked, what failed, what's untried)
   3. Make ONE focused change
@@ -29,7 +30,7 @@ LOOP FOREVER:
   5. Run mechanical verification (tests, benchmarks, scores)
   6. If improved → keep. If worse → git revert. If crashed → fix or skip.
   7. Log the result
-  8. Repeat. NEVER STOP. NEVER ASK "should I continue?"
+  8. Repeat. Default: NEVER STOP. With /loop N: stop after N iterations.
 ```
 
 Every improvement stacks. Every failure auto-reverts. Progress is logged in TSV format.
@@ -103,7 +104,59 @@ Claude will:
 4. Keep improvements, auto-revert failures
 5. Log every iteration in `autoresearch-results.tsv`
 6. Print a summary every 10 iterations
-7. **Never stop until you interrupt**
+7. **Never stop until you interrupt** (or until N iterations complete in bounded mode)
+
+---
+
+## Controlled Iterations with `/loop` (v1.0.1)
+
+> **Requires:** Claude Code **v1.0.32+** (the `/loop` command was introduced in this version)
+
+By default, autoresearch loops **forever** until manually interrupted. Starting in v1.0.1, you can optionally specify a **loop count** using Claude Code's built-in `/loop` command to run a fixed number of iterations.
+
+### Usage
+
+**Unlimited (default) — loop forever:**
+```
+/autoresearch
+Goal: Increase test coverage to 90%
+```
+
+**Bounded — run exactly N iterations:**
+```
+/loop 25 /autoresearch
+Goal: Increase test coverage to 90%
+```
+
+This chains `/autoresearch` with `/loop 25`, running exactly 25 iteration cycles. After 25 iterations, Claude stops and prints a final summary.
+
+### When to Use Bounded Loops
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Run overnight, review in morning | Unlimited (default) |
+| Quick 30-min improvement session | `/loop 10 /autoresearch` |
+| Targeted fix with known scope | `/loop 5 /autoresearch` |
+| Exploratory — see if approach works | `/loop 15 /autoresearch` |
+| CI/CD pipeline integration | `/loop N /autoresearch` (set N based on time budget) |
+
+### Behavior with Loop Count
+
+When a loop count is specified:
+- Claude runs exactly **N iterations** through the autoresearch loop
+- After iteration N, Claude prints a **final summary** with baseline → current best, keeps/discards/crashes
+- If the goal is achieved before N iterations, Claude prints **early completion** and stops
+- All other rules (atomic changes, mechanical verification, auto-rollback) still apply
+- When **fewer than 3 iterations remain**, Claude prioritizes **exploiting successes** over exploration
+
+### Final Summary Format
+
+```
+=== Autoresearch Complete (25/25 iterations) ===
+Baseline: 72.0% → Final: 89.3% (+17.3%)
+Keeps: 12 | Discards: 11 | Crashes: 2
+Best iteration: #18 — add tests for payment processing edge cases
+```
 
 ---
 
@@ -151,7 +204,7 @@ Each iteration follows an 8-phase protocol:
 │  Append result to autoresearch-results.tsv          │
 │                                                     │
 │  Phase 8: REPEAT                                    │
-│  Go to Phase 1. NEVER STOP.                         │
+│  Go to Phase 1. Default: forever. /loop N: N times. │
 │                                                     │
 └─────────────────────────────────────────────────────┘
 ```
@@ -880,7 +933,7 @@ These rules govern Claude's behavior during the autonomous loop:
 
 | # | Rule | Why |
 |---|------|-----|
-| 1 | **NEVER STOP** | Loop until manually interrupted. User may be asleep. |
+| 1 | **Loop until done** | Unbounded: loop until interrupted. Bounded (`/loop N`): loop N times then summarize. |
 | 2 | **Read before write** | Always understand full context before modifying. |
 | 3 | **One change per iteration** | Atomic changes — if it breaks, you know exactly why. |
 | 4 | **Mechanical verification only** | No subjective "looks good." Use metrics. |
@@ -951,7 +1004,10 @@ The meta-principle:
 A: Yes. Copy the skill to `.claude/skills/autoresearch/` in any project. It works with any language, framework, or domain.
 
 **Q: How do I stop the loop?**
-A: Press `Ctrl+C` or close the terminal. Claude commits before verifying, so your last successful state is always preserved in git.
+A: Press `Ctrl+C` or close the terminal. Or use `/loop N /autoresearch` to run exactly N iterations and stop automatically. Claude commits before verifying, so your last successful state is always preserved in git.
+
+**Q: How do I run a fixed number of iterations?**
+A: Use `/loop N /autoresearch` (requires Claude Code v1.0.32+). For example, `/loop 25 /autoresearch` runs exactly 25 iterations then prints a summary and stops. See the "Controlled Iterations" section above.
 
 **Q: What if my verification takes too long?**
 A: Aim for under 10 seconds. Longer verification = fewer experiments = slower progress. Use the fastest check that still catches real problems.

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,20 +1,60 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat forever until stopped.
-version: 1.0.0
+description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
+version: 1.0.1
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
 
 Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch). Applies constraint-driven autonomous iteration to ANY work — not just ML research.
 
-**Core idea:** You are an autonomous agent. Modify → Verify → Keep/Discard → Repeat. Never stop.
+**Core idea:** You are an autonomous agent. Modify → Verify → Keep/Discard → Repeat.
 
 ## When to Activate
 
 - User invokes `/autoresearch` or `/ug:autoresearch`
 - User says "work autonomously", "iterate until done", "keep improving", "run overnight"
 - Any task requiring repeated iteration cycles with measurable outcomes
+
+## Optional: Controlled Loop Count
+
+By default, autoresearch loops **forever** until manually interrupted. However, users can optionally specify a **loop count** to limit iterations using Claude Code's built-in `/loop` command.
+
+> **Requires:** Claude Code v1.0.32+ (the `/loop` command was introduced in this version)
+
+### Usage
+
+**Unlimited (default):**
+```
+/autoresearch
+Goal: Increase test coverage to 90%
+```
+
+**Bounded (N iterations):**
+```
+/loop 25 /autoresearch
+Goal: Increase test coverage to 90%
+```
+
+This chains `/autoresearch` with `/loop 25`, running exactly 25 iteration cycles. After 25 iterations, Claude stops and prints a final summary.
+
+### When to Use Bounded Loops
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Run overnight, review in morning | Unlimited (default) |
+| Quick 30-min improvement session | `/loop 10 /autoresearch` |
+| Targeted fix with known scope | `/loop 5 /autoresearch` |
+| Exploratory — see if approach works | `/loop 15 /autoresearch` |
+| CI/CD pipeline integration | `/loop N /autoresearch` (set N based on time budget) |
+
+### Behavior with Loop Count
+
+When a loop count is specified:
+- Claude runs exactly N iterations through the autoresearch loop
+- After iteration N, Claude prints a **final summary** with baseline → current best, keeps/discards/crashes
+- If the goal is achieved before N iterations, Claude prints early completion and stops
+- All other rules (atomic changes, mechanical verification, auto-rollback) still apply
 
 ## Setup Phase (Do Once)
 
@@ -29,12 +69,12 @@ Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch).
 5. **Establish baseline** — Run verification on current state. Record as iteration #0
 6. **Confirm and go** — Show user the setup, get confirmation, then BEGIN THE LOOP
 
-## The Loop (Runs Forever)
+## The Loop
 
 Read `references/autonomous-loop-protocol.md` for full protocol details.
 
 ```
-LOOP FOREVER:
+LOOP (FOREVER or N times):
   1. Review: Read current state + git history + results log
   2. Ideate: Pick next change based on goal, past results, what hasn't been tried
   3. Modify: Make ONE focused change to in-scope files
@@ -45,12 +85,14 @@ LOOP FOREVER:
      - SAME/WORSE → Git revert, log "discard"
      - CRASHED → Try to fix (max 3 attempts), else log "crash" and move on
   7. Log: Record result in results log
-  8. Repeat: Go to step 1. NEVER STOP. NEVER ASK "should I continue?"
+  8. Repeat: Go to step 1.
+     - If unbounded: NEVER STOP. NEVER ASK "should I continue?"
+     - If bounded (N): Stop after N iterations, print final summary
 ```
 
 ## Critical Rules
 
-1. **NEVER STOP** — Loop until manually interrupted. User may be asleep.
+1. **Loop until done** — Unbounded: loop until interrupted. Bounded: loop N times then summarize.
 2. **Read before write** — Always understand full context before modifying
 3. **One change per iteration** — Atomic changes. If it breaks, you know exactly why
 4. **Mechanical verification only** — No subjective "looks good". Use metrics

--- a/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -2,6 +2,15 @@
 
 Detailed protocol for the autoresearch iteration loop. SKILL.md has the summary; this file has the full rules.
 
+## Loop Modes
+
+Autoresearch supports two loop modes:
+
+- **Unbounded (default):** Loop forever until manually interrupted (`Ctrl+C`)
+- **Bounded:** Loop exactly N times when chained with `/loop N` (requires Claude Code v1.0.32+)
+
+When bounded, track `current_iteration` against `max_iterations`. After the final iteration, print a summary and stop.
+
 ## Phase 1: Review (30 seconds)
 
 Before each iteration, build situational awareness:
@@ -11,6 +20,7 @@ Before each iteration, build situational awareness:
 2. Read last 10-20 entries from results log
 3. Read git log --oneline -20 to see recent changes
 4. Identify: what worked, what failed, what's untried
+5. If bounded: check current_iteration vs max_iterations
 ```
 
 **Why read every time?** After rollbacks, state may differ from what you expect. Never assume — always verify.
@@ -30,6 +40,8 @@ Pick the NEXT change. Priority order:
 - Don't repeat exact same change that was already discarded
 - Don't make multiple unrelated changes at once (can't attribute improvement)
 - Don't chase marginal gains with ugly complexity
+
+**Bounded mode consideration:** If remaining iterations are limited (<3 left), prioritize exploiting successes over exploration.
 
 ## Phase 3: Modify (One Atomic Change)
 
@@ -87,9 +99,35 @@ iteration  commit   metric   status   description
 
 ## Phase 8: Repeat
 
+### Unbounded Mode (default)
+
 Go to Phase 1. **NEVER STOP. NEVER ASK IF YOU SHOULD CONTINUE.**
 
-If stuck (>5 consecutive discards):
+### Bounded Mode (with /loop N)
+
+```
+IF current_iteration < max_iterations:
+    Go to Phase 1
+ELIF goal_achieved:
+    Print: "Goal achieved at iteration {N}! Final metric: {value}"
+    Print final summary
+    STOP
+ELSE:
+    Print final summary
+    STOP
+```
+
+**Final summary format:**
+```
+=== Autoresearch Complete (N/N iterations) ===
+Baseline: {baseline} → Final: {current} ({delta})
+Keeps: X | Discards: Y | Crashes: Z
+Best iteration: #{n} — {description}
+```
+
+### When Stuck (>5 consecutive discards)
+
+Applies to both modes:
 1. Re-read ALL in-scope files from scratch
 2. Re-read the original goal/direction
 3. Review entire results log for patterns
@@ -107,7 +145,8 @@ If stuck (>5 consecutive discards):
 
 ## Communication
 
-- **DO NOT** ask "should I keep going?" — YES. ALWAYS.
+- **DO NOT** ask "should I keep going?" — in unbounded mode, YES. ALWAYS. In bounded mode, continue until N is reached.
 - **DO NOT** summarize after each iteration — just log and continue
 - **DO** print a brief one-line status every ~5 iterations (e.g., "Iteration 25: metric at 0.95, 8 keeps / 17 discards")
 - **DO** alert if you discover something surprising or game-changing
+- **DO** print a final summary when bounded loop completes

--- a/skills/autoresearch/references/results-logging.md
+++ b/skills/autoresearch/references/results-logging.md
@@ -43,7 +43,7 @@ iteration	commit	metric	delta	status	description
 
 ## Summary Reporting
 
-Every 10 iterations, print a brief summary:
+Every 10 iterations (or at loop completion in bounded mode), print a brief summary:
 
 ```
 === Autoresearch Progress (iteration 20) ===


### PR DESCRIPTION
## Summary

Introduces v1.0.1 of Claude Autoresearch with optional bounded loop count support via Claude Code's built-in `/loop` command, giving users control over how many iterations to run.

### Problem

The original autoresearch skill only supported unbounded mode — it loops forever until manually interrupted (`Ctrl+C`). While powerful for overnight runs, many users want:
- **Quick improvement sessions** — "run 10 iterations and stop"
- **CI/CD integration** — "run N iterations within my time budget"
- **Exploratory testing** — "try 15 iterations to see if this approach works"

### Solution

Chain autoresearch with Claude Code's built-in `/loop` command (introduced in v1.0.32):

```
# Unlimited (default) — loop forever
/autoresearch
Goal: Increase test coverage to 90%

# Bounded — exactly 25 iterations
/loop 25 /autoresearch
Goal: Increase test coverage to 90%
```

### What Changed

#### SKILL.md (v1.0.0 → v1.0.1)

- Added "Optional: Controlled Loop Count" section with Claude Code v1.0.32+ requirement
- Added usage examples for unlimited and bounded modes
- Added "When to Use Bounded Loops" decision table
- Added "Behavior with Loop Count" documentation
- Updated loop pseudocode from `LOOP FOREVER` to `LOOP (FOREVER or N times)`
- Updated Critical Rule #1 from "NEVER STOP" to "Loop until done" covering both modes

#### references/autonomous-loop-protocol.md

- Added "Loop Modes" section at top explaining unbounded vs bounded
- Phase 1 (Review): Added step 5 — check `current_iteration` vs `max_iterations`
- Phase 2 (Ideate): Added bounded mode consideration — prioritize exploitation when <3 iterations left
- Phase 8 (Repeat): Split into "Unbounded Mode" and "Bounded Mode" subsections with final summary format
- Communication: Updated rules to cover both modes

#### references/results-logging.md

- Updated summary reporting to mention "or at loop completion in bounded mode"

#### README.md

- Added version badge (v1.0.1)
- Updated loop pseudocode to show both modes
- Added full "Controlled Iterations with `/loop`" section with:
  - Claude Code v1.0.32+ requirement callout
  - Usage examples (unlimited vs bounded)
  - "When to Use Bounded Loops" decision table
  - Bounded mode behavior documentation
  - Final summary format example
- Updated loop diagram Phase 8 text
- Updated Critical Rules table (Rule #1)
- Added two new FAQ entries about loop count
- Updated "Walk Away" step 7 to mention bounded mode

### Bounded Mode Behavior

| Feature | Detail |
|---------|--------|
| Fixed iterations | Runs exactly N times through the loop |
| Final summary | Prints baseline → current best, keeps/discards/crashes |
| Early completion | Stops and reports when goal achieved before N iterations |
| Smart exploitation | Prioritizes exploiting successes over exploration when <3 iterations remain |
| Backward compatible | All existing rules still apply (atomic changes, verification, rollback) |
| Version requirement | Claude Code v1.0.32+ (when `/loop` was introduced) |

### Final Summary Format

```
=== Autoresearch Complete (25/25 iterations) ===
Baseline: 72.0% → Final: 89.3% (+17.3%)
Keeps: 12 | Discards: 11 | Crashes: 2
Best iteration: #18 — add tests for payment processing edge cases
```

## Test plan

- [x] Verify `/autoresearch` still works in unbounded mode (default behavior unchanged)
- [x] Verify `/loop N /autoresearch` runs exactly N iterations (requires Claude Code v1.0.32+)
- [x] Verify final summary prints after bounded loop completes
- [x] Verify early completion when goal achieved before N iterations
- [x] Verify exploitation priority when <3 iterations remain
- [x] Verify README renders correctly with new sections
- [x] Verify version badge displays correctly