### PR TITLE
docs: surface red-team adversarial personas in commands reference and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) —
 | `/autoresearch` | Run the autonomous iteration loop (unlimited) | v1.0.0 |
 | `/loop N /autoresearch` | Run exactly N iterations then stop | v1.0.1 |
 | `/autoresearch:plan` | Interactive wizard: Goal → Scope, Metric, Verify config | v1.0.2 |
-| `/autoresearch:security` | Autonomous STRIDE + OWASP security audit | v1.0.3 |
+| `/autoresearch:security` | Autonomous STRIDE + OWASP + red-team security audit | v1.0.3 |
 | `/autoresearch:security --diff` | Delta mode — only audit files changed since last audit | v1.0.3 |
 | `/autoresearch:security --fix` | Auto-fix confirmed Critical/High findings after audit | v1.0.3 |
 | `/autoresearch:security --fail-on critical` | Exit non-zero if severity threshold met (CI/CD gate) | v1.0.3 |
 | `/loop N /autoresearch:security` | Bounded security audit (N iterations) | v1.0.3 |
+
+**Security audit includes:** STRIDE threat model, OWASP Top 10 (70+ checks), 4 red-team adversarial personas (Security Adversary, Supply Chain Attacker, Insider Threat, Infrastructure Attacker), proof-of-concept validation, structured report folder, historical comparison.
 
 ### Flag Combinations
 
@@ -47,6 +49,7 @@ Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) —
 | Improve test coverage / reduce bundle size / any metric | `/autoresearch` or `/loop N /autoresearch` |
 | Don't know what metric to use | `/autoresearch:plan` |
 | Run a security audit | `/autoresearch:security` or `/loop 10 /autoresearch:security` |
+| Red-team my codebase | `/autoresearch:security` (includes 4 adversarial personas) |
 | Audit only changed files (PR review) | `/autoresearch:security --diff` |
 | Auto-fix security issues | `/autoresearch:security --fix` |
 | Block CI pipeline on vulnerabilities | `/autoresearch:security --fail-on critical` |

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -16,7 +16,7 @@ Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch).
 |------------|---------|
 | `/autoresearch` | Run the autonomous loop (default) |
 | `/autoresearch:plan` | Interactive wizard to build Scope, Metric, Direction & Verify from a Goal |
-| `/autoresearch:security` | Autonomous security audit with STRIDE threat model + OWASP Top 10 sweep |
+| `/autoresearch:security` | Autonomous security audit: STRIDE threat model + OWASP Top 10 + red-team (4 adversarial personas) |
 
 ### /autoresearch:security — Autonomous Security Audit (v1.0.3)
 


### PR DESCRIPTION
## Summary

The red-team adversarial analysis (4 hostile personas: Security Adversary, Supply Chain Attacker, Insider Threat, Infrastructure Attacker) was fully implemented in \`security-workflow.md\` and mentioned in the security section body, but was **not visible** in the Commands Reference table, Quick Decision Guide, or SKILL.md sub-command description.

### Changes

1. **Commands Reference table** — Updated \`/autoresearch:security\` description from \"STRIDE + OWASP\" to \"STRIDE + OWASP + red-team\"
2. **Summary line** — Added a line below the commands table listing all components: STRIDE, OWASP Top 10 (70+ checks), 4 red-team personas, PoC validation, structured report folder, historical comparison
3. **Quick Decision Guide** — Added \"Red-team my codebase\" → \`/autoresearch:security\` row
4. **SKILL.md** — Updated sub-command table description to include \"red-team (4 adversarial personas)\"

### Why

Users scanning the commands reference or decision guide should immediately see that red-team analysis is a core capability, not have to scroll deep into the security section to discover it.

## Files Changed

| File | Change |
|------|--------|
| \`README.md\` | +3 lines: red-team in commands table, summary, decision guide |
| \`SKILL.md\` | +1 line: red-team in sub-command description |