### PR TITLE
Add guard rule

### DIFF
--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.0.3
+version: 1.1.0
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
@@ -174,9 +174,10 @@ When a loop count is specified:
    - Design: lighthouse score, accessibility audit passes
    - If no metric exists → define one with user, or use simplest proxy (e.g. "compiles without errors")
 3. **Define scope constraints** — Which files can you modify? Which are read-only?
-4. **Create a results log** — Track every iteration (see `references/results-logging.md`)
-5. **Establish baseline** — Run verification on current state. Record as iteration #0
-6. **Confirm and go** — Show user the setup, get confirmation, then BEGIN THE LOOP
+4. **Define guard (optional)** — A command that must ALWAYS pass for a change to be kept. Use this to prevent regressions while optimizing the main metric (e.g., `npm test` must pass while optimizing benchmark time). If not specified, no guard is enforced.
+5. **Create a results log** — Track every iteration (see `references/results-logging.md`)
+6. **Establish baseline** — Run verification on current state AND guard (if set). Record as iteration #0
+7. **Confirm and go** — Show user the setup, get confirmation, then BEGIN THE LOOP
 
 ## The Loop
 
@@ -189,12 +190,17 @@ LOOP (FOREVER or N times):
   3. Modify: Make ONE focused change to in-scope files
   4. Commit: Git commit the change (before verification)
   5. Verify: Run the mechanical metric (tests, build, benchmark, etc.)
-  6. Decide:
-     - IMPROVED → Keep commit, log "keep", advance
+  6. Guard: If guard is set, run the guard command
+  7. Decide:
+     - IMPROVED + guard passed (or no guard) → Keep commit, log "keep", advance
+     - IMPROVED + guard FAILED → Revert, then try to rework the optimization
+       (max 2 attempts) so it improves the metric WITHOUT breaking the guard.
+       Never modify guard/test files — adapt the implementation instead.
+       If still failing → log "discard (guard failed)" and move on
      - SAME/WORSE → Git revert, log "discard"
      - CRASHED → Try to fix (max 3 attempts), else log "crash" and move on
-  7. Log: Record result in results log
-  8. Repeat: Go to step 1.
+  8. Log: Record result in results log
+  9. Repeat: Go to step 1.
      - If unbounded: NEVER STOP. NEVER ASK "should I continue?"
      - If bounded (N): Stop after N iterations, print final summary
 ```
@@ -216,14 +222,14 @@ See `references/core-principles.md` for the 7 generalizable principles from auto
 
 ## Adapting to Different Domains
 
-| Domain | Metric | Scope | Verify Command |
-|--------|--------|-------|----------------|
-| Backend code | Tests pass + coverage % | `src/**/*.ts` | `npm test` |
-| Frontend UI | Lighthouse score | `src/components/**` | `npx lighthouse` |
-| ML training | val_bpb / loss | `train.py` | `uv run train.py` |
-| Blog/content | Word count + readability | `content/*.md` | Custom script |
-| Performance | Benchmark time (ms) | Target files | `npm run bench` |
-| Refactoring | Tests pass + LOC reduced | Target module | `npm test && wc -l` |
-| Security | OWASP + STRIDE coverage + findings | API/auth/middleware | `/autoresearch:security` |
+| Domain | Metric | Scope | Verify Command | Guard |
+|--------|--------|-------|----------------|-------|
+| Backend code | Tests pass + coverage % | `src/**/*.ts` | `npm test` | — |
+| Frontend UI | Lighthouse score | `src/components/**` | `npx lighthouse` | `npm test` |
+| ML training | val_bpb / loss | `train.py` | `uv run train.py` | — |
+| Blog/content | Word count + readability | `content/*.md` | Custom script | — |
+| Performance | Benchmark time (ms) | Target files | `npm run bench` | `npm test` |
+| Refactoring | Tests pass + LOC reduced | Target module | `npm test && wc -l` | `npm run typecheck` |
+| Security | OWASP + STRIDE coverage + findings | API/auth/middleware | `/autoresearch:security` | — |
 
 Adapt the loop to your domain. The PRINCIPLES are universal; the METRICS are domain-specific.

--- a/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -66,19 +66,68 @@ Run the agreed-upon verification command. Capture output.
 
 **Extract metric:** Parse the verification output for the specific metric number.
 
+## Phase 5.5: Guard (Regression Check)
+
+If a **guard** command was defined during setup, run it after verification.
+
+The guard is a command that must ALWAYS pass — it protects existing functionality while the main metric is being optimized. Common guards: `npm test`, `npm run typecheck`, `pytest`, `cargo test`.
+
+**Key distinction:**
+- **Verify** answers: "Did the metric improve?" (the goal)
+- **Guard** answers: "Did anything else break?" (the safety net)
+
+**Guard rules:**
+- Only run if a guard was defined (it's optional)
+- Run AFTER verify — no point checking guard if the metric didn't improve
+- Guard is pass/fail only (exit code 0 = pass). No metric extraction needed
+- If guard fails, revert the optimization and try to rework it (max 2 attempts)
+- NEVER modify guard/test files — always adapt the implementation instead
+- Log guard failures distinctly so the agent can learn what kinds of changes cause regressions
+
+**Guard failure recovery (max 2 rework attempts):**
+
+When the guard fails but the metric improved, the optimization idea may still be viable — it just needs a different implementation that doesn't break behavior:
+
+1. Revert the change (`git reset --hard HEAD~1`)
+2. Read the guard output to understand WHAT broke (which tests, which assertions)
+3. Rework the optimization to avoid the regression — e.g.:
+   - If inlining a function broke callers → try a different optimization angle
+   - If changing a data structure broke serialization → preserve the interface
+   - If reordering logic broke edge cases → add the optimization more surgically
+4. Commit the reworked version, re-run verify + guard
+5. If both pass → keep. If guard fails again → one more attempt, then give up
+
+**Critical:** Guard/test files are read-only. The optimization must adapt to the tests, never the other way around. If after 2 rework attempts the optimization can't pass the guard, discard it and move on to a different idea.
+
 ## Phase 6: Decide (No Ambiguity)
 
 ```
-IF metric_improved:
+IF metric_improved AND (no guard OR guard_passed):
     STATUS = "keep"
     # Do nothing — commit stays
+ELIF metric_improved AND guard_failed:
+    git reset --hard HEAD~1
+    # Rework the optimization (max 2 attempts)
+    FOR attempt IN 1..2:
+        Analyze guard output → rework implementation (NOT tests)
+        git add + commit reworked version
+        Re-run verify
+        IF metric_improved:
+            Re-run guard
+            IF guard_passed:
+                STATUS = "keep (reworked)"
+                BREAK
+        git reset --hard HEAD~1
+    IF still failing after 2 attempts:
+        STATUS = "discard"
+        REASON = "guard failed, could not rework optimization"
 ELIF metric_same_or_worse:
     STATUS = "discard"
     git reset --hard HEAD~1
 ELIF crashed:
     # Attempt fix (max 3 tries)
     IF fixable:
-        Fix → re-commit → re-verify
+        Fix → re-commit → re-verify → re-guard
     ELSE:
         STATUS = "crash"
         git reset --hard HEAD~1

--- a/skills/autoresearch/references/results-logging.md
+++ b/skills/autoresearch/references/results-logging.md
@@ -7,7 +7,7 @@ Track every iteration in a structured log. Enables pattern recognition and preve
 Create `autoresearch-results.tsv` in the working directory (gitignored):
 
 ```tsv
-iteration	commit	metric	delta	status	description
+iteration	commit	metric	delta	guard	status	description
 ```
 
 ### Columns
@@ -18,20 +18,24 @@ iteration	commit	metric	delta	status	description
 | commit | string | Short git hash (7 chars), "-" if reverted |
 | metric | float | Measured value from verification |
 | delta | float | Change from previous best (negative = improved for "lower is better") |
+| guard | enum | `pass`, `fail`, or `-` (no guard configured) |
 | status | enum | `baseline`, `keep`, `discard`, `crash` |
 | description | string | One-sentence description of what was tried |
 
 ### Example
 
 ```tsv
-iteration	commit	metric	delta	status	description
-0	a1b2c3d	85.2	0.0	baseline	initial state — test coverage 85.2%
-1	b2c3d4e	87.1	+1.9	keep	add tests for auth middleware edge cases
-2	-	86.5	-0.6	discard	refactor test helpers (broke 2 tests)
-3	-	0.0	0.0	crash	add integration tests (DB connection failed)
-4	c3d4e5f	88.3	+1.2	keep	add tests for error handling in API routes
-5	d4e5f6g	89.0	+0.7	keep	add boundary value tests for validators
+iteration	commit	metric	delta	guard	status	description
+0	a1b2c3d	85.2	0.0	pass	baseline	initial state — test coverage 85.2%
+1	b2c3d4e	87.1	+1.9	pass	keep	add tests for auth middleware edge cases
+2	-	86.5	-0.6	-	discard	refactor test helpers (broke 2 tests)
+3	-	0.0	0.0	-	crash	add integration tests (DB connection failed)
+4	-	88.9	+1.8	fail	discard	inline hot-path functions (guard: 3 tests broke)
+5	c3d4e5f	88.3	+1.2	pass	keep	add tests for error handling in API routes
+6	d4e5f6g	89.0	+0.7	pass	keep	add boundary value tests for validators
 ```
+
+**Note:** When guard fails, the metric may have improved but the change is still discarded. The guard column makes this visible in the log so the agent can learn which optimization approaches tend to cause regressions.
 
 ## Log Management
 


### PR DESCRIPTION
While using the autoresearch skill I noticed that sometimes the optimization might break the core behaviour. The workaround that worked for me was to ask running tests along with the measurement in the `Verify ` option. 

With this PR, I'd like to propose adding a separate `Guard` option that would help prevent behaviour regressions.

- Introduced optional guard command for regression checks during the loop.
- Updated protocol and flow to handle guard failures with rework attempts.
- Adjusted logging format to include guard status for improved traceability.
- Revised examples and tables to reflect guard integration.
