### PR TITLE
feat: polish Guard — version fix, README docs, plan wizard integration (v1.0.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — the principle that **constraint + mechanical metric + autonomous iteration = compounding gains**.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.0.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.0.4-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 
@@ -23,6 +23,7 @@ Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) —
 | `/autoresearch:security --fix` | Auto-fix confirmed Critical/High findings after audit | v1.0.3 |
 | `/autoresearch:security --fail-on critical` | Exit non-zero if severity threshold met (CI/CD gate) | v1.0.3 |
 | `/loop N /autoresearch:security` | Bounded security audit (N iterations) | v1.0.3 |
+| `Guard: <command>` | Optional safety net — must pass for changes to be kept (regression prevention) | v1.0.4 |
 
 **Security audit includes:** STRIDE threat model, OWASP Top 10 (70+ checks), 4 red-team adversarial personas (Security Adversary, Supply Chain Attacker, Insider Threat, Infrastructure Attacker), proof-of-concept validation, structured report folder, historical comparison.
 
@@ -53,6 +54,40 @@ Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) —
 | Audit only changed files (PR review) | `/autoresearch:security --diff` |
 | Auto-fix security issues | `/autoresearch:security --fix` |
 | Block CI pipeline on vulnerabilities | `/autoresearch:security --fail-on critical` |
+| Optimize without breaking existing tests | Add `Guard: npm test` to your config |
+
+### Guard — Prevent Regressions While Optimizing (v1.0.4)
+
+When optimizing a metric (e.g., benchmark time), the loop might break existing behavior. **Guard** is an optional safety net — a command that must ALWAYS pass for a change to be kept.
+
+```
+/autoresearch
+Goal: Reduce API response time to under 100ms
+Metric: p95 response time in ms (lower is better)
+Verify: npm run bench:api | grep "p95"
+Guard: npm test
+Scope: src/api/**/*.ts
+```
+
+**How it works:**
+- **Verify** = "Did the metric improve?" (the goal)
+- **Guard** = "Did anything else break?" (the safety net)
+
+If the metric improves but the guard fails, Claude **reworks the optimization** (up to 2 attempts) to find an approach that improves the metric WITHOUT breaking the guard. Guard/test files are never modified.
+
+**When to use Guard:**
+
+| Scenario | Verify | Guard |
+|----------|--------|-------|
+| Reduce bundle size | `npm run build \| grep size` | `npm test` |
+| Optimize Lighthouse | `npx lighthouse --output json` | `npm test` |
+| Reduce LOC (refactoring) | `wc -l src/**/*.ts` | `npm test && npm run typecheck` |
+| Improve benchmark time | `npm run bench` | `npm test` |
+| Increase coverage | `jest --coverage` | *(no guard needed — tests ARE the metric)* |
+
+Guard is **optional** — if not specified, the loop works exactly as before.
+
+> **Credit:** Guard was contributed by [@pronskiy](https://github.com/pronskiy) (JetBrains) in [PR #7](https://github.com/uditgoenka/autoresearch/pull/7).
 
 ---
 

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.1.0
+version: 1.0.4
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/skills/autoresearch/references/plan-workflow.md
+++ b/skills/autoresearch/references/plan-workflow.md
@@ -91,6 +91,32 @@ AskUserQuestion:
 
 If metric fails validation, explain why and suggest alternatives. **Do not proceed until metric is mechanical.**
 
+### Phase 4.5: Define Guard (Optional)
+
+Ask if the user wants a guard command to prevent regressions:
+
+```
+AskUserQuestion:
+  question: "Do you want a guard command? This is a safety net that must ALWAYS pass — it prevents breaking existing behavior while optimizing."
+  header: "Guard"
+  options:
+    - label: "Yes — run tests as guard (Recommended)"
+      description: "{detected_test_command} must pass for every kept change"
+    - label: "Yes — custom guard"
+      description: "I'll provide my own guard command"
+    - label: "No guard needed"
+      description: "Skip — the metric is enough (e.g., test coverage where tests ARE the metric)"
+```
+
+**Guard suggestion rules:**
+- If metric is performance/benchmark/bundle size → suggest `{test_command}` as guard
+- If metric is Lighthouse/accessibility → suggest `{test_command}` as guard
+- If metric is refactoring (LOC reduction) → suggest `{test_command} && {typecheck_command}` as guard
+- If metric IS tests (coverage, pass count) → suggest "No guard needed" as default
+- If no test runner detected → suggest "No guard needed" with note
+
+**Guard validation:** If guard is set, run it once to confirm it passes on current codebase. If it fails, help user fix it before proceeding.
+
 ### Phase 5: Define Direction
 
 ```
@@ -156,6 +182,7 @@ Present the complete configuration:
 **Scope:** {glob pattern}
 **Metric:** {metric name} ({direction})
 **Verify:** `{command}`
+**Guard:** `{guard_command}` *(or "none")*
 **Baseline:** {value from dry run}
 
 ### Ready-to-use command:
@@ -165,7 +192,10 @@ Goal: {goal}
 Scope: {scope}
 Metric: {metric} ({direction})
 Verify: {verify_command}
+Guard: {guard_command}
 ```
+
+If no guard was set, omit the Guard line from the output.
 
 Then ask:
 


### PR DESCRIPTION
## Summary

Polishes the Guard feature from PR #7 (by @pronskiy) with 4 improvements: version fix, README documentation, plan wizard integration, and commands table update.

### Changes

**1. Version Fix: v1.1.0 → v1.0.4**
Guard is an additive, backward-compatible feature — v1.0.4 is the correct semver bump.

**2. README — Guard Section (after Quick Decision Guide)**
Added a complete Guard usage guide with:
- What Guard is and how it differs from Verify
- Code example showing Guard in a real config
- "When to use Guard" table (5 scenarios with verify/guard pairings)
- Note that Guard is optional
- Credit to @pronskiy (JetBrains) with PR link

**3. /autoresearch:plan — Phase 4.5: Define Guard**
The planning wizard now asks about Guard during setup:
- Suggests \`{test_command}\` as guard when metric is performance/bundle/lighthouse
- Suggests "No guard needed" when metric IS tests (coverage)
- Validates guard command passes on current codebase
- Includes Guard in the final config output

**4. Commands Reference Table**
Added Guard row to the commands table at top of README.

## Files Changed

| File | Change |
|------|--------|
| \`SKILL.md\` | Version fix: v1.1.0 → v1.0.4 |
| \`README.md\` | +37 lines: Guard section, commands table row, version badge |
| \`references/plan-workflow.md\` | +30 lines: Phase 4.5 (Define Guard), updated config output |

## Credit

Guard concept and core implementation by [@pronskiy](https://github.com/pronskiy) (JetBrains) in [PR #7](https://github.com/uditgoenka/autoresearch/pull/7).