### PR TITLE
feat: add /autoresearch:ship — universal shipping workflow (v1.1.0)

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: autoresearch
+description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
+version: 1.1.0
+---
+
+# Claude Autoresearch — Autonomous Goal-directed Iteration
+
+Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch). Applies constraint-driven autonomous iteration to ANY work — not just ML research.
+
+**Core idea:** You are an autonomous agent. Modify → Verify → Keep/Discard → Repeat.
+
+## Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `/autoresearch` | Run the autonomous loop (default) |
+| `/autoresearch:plan` | Interactive wizard to build Scope, Metric, Direction & Verify from a Goal |
+| `/autoresearch:security` | Autonomous security audit: STRIDE threat model + OWASP Top 10 + red-team (4 adversarial personas) |
+| `/autoresearch:ship` | Universal shipping workflow: ship code, content, marketing, sales, research, or anything |
+
+### /autoresearch:security — Autonomous Security Audit (v1.0.3)
+
+Runs a comprehensive security audit using the autoresearch loop pattern. Generates a full STRIDE threat model, maps attack surfaces, then iteratively tests each vulnerability vector — logging findings with severity, OWASP category, and code evidence.
+
+Load: `references/security-workflow.md` for full protocol.
+
+**What it does:**
+
+1. **Codebase Reconnaissance** — scans tech stack, dependencies, configs, API routes
+2. **Asset Identification** — catalogs data stores, auth systems, external services, user inputs
+3. **Trust Boundary Mapping** — browser↔server, public↔authenticated, user↔admin, CI/CD↔prod
+4. **STRIDE Threat Model** — Spoofing, Tampering, Repudiation, Info Disclosure, DoS, Elevation of Privilege
+5. **Attack Surface Map** — entry points, data flows, abuse paths
+6. **Autonomous Loop** — iteratively tests each vector, validates with code evidence, logs findings
+7. **Final Report** — severity-ranked findings with mitigations, coverage matrix, iteration log
+
+**Key behaviors:**
+- Follows red-team adversarial mindset (Security Adversary, Supply Chain, Insider Threat, Infra Attacker)
+- Every finding requires **code evidence** (file:line + attack scenario) — no theoretical fluff
+- Tracks OWASP Top 10 + STRIDE coverage, prints coverage summary every 5 iterations
+- Composite metric: `(owasp_tested/10)*50 + (stride_tested/6)*30 + min(findings, 20)` — higher is better
+- Creates `security/{YYMMDD}-{HHMM}-{audit-slug}/` folder with structured reports:
+  `overview.md`, `threat-model.md`, `attack-surface-map.md`, `findings.md`, `owasp-coverage.md`, `dependency-audit.md`, `recommendations.md`, `security-audit-results.tsv`
+
+**Flags:**
+
+| Flag | Purpose |
+|------|---------|
+| `--diff` | Delta mode — only audit files changed since last audit |
+| `--fix` | After audit, auto-fix confirmed Critical/High findings using autoresearch loop |
+| `--fail-on {severity}` | Exit non-zero if findings meet threshold (for CI/CD gating) |
+
+**Usage:**
+```
+# Unlimited — keep finding vulnerabilities until interrupted
+/autoresearch:security
+
+# Bounded — exactly 10 security sweep iterations
+/loop 10 /autoresearch:security
+
+# With focused scope
+/autoresearch:security
+Scope: src/api/**/*.ts, src/middleware/**/*.ts
+Focus: authentication and authorization flows
+
+# Delta mode — only audit changed files since last audit
+/autoresearch:security --diff
+
+# Auto-fix confirmed Critical/High findings after audit
+/loop 15 /autoresearch:security --fix
+
+# CI/CD gate — fail pipeline if any Critical findings
+/loop 10 /autoresearch:security --fail-on critical
+
+# Combined — delta audit + fix + gate
+/loop 15 /autoresearch:security --diff --fix --fail-on critical
+```
+
+**Inspired by:**
+- [Strix](https://github.com/usestrix/strix) — AI-powered security testing with proof-of-concept validation
+- `/plan red-team` — adversarial review with hostile reviewer personas
+- OWASP Top 10 (2021) — industry-standard vulnerability taxonomy
+- STRIDE — Microsoft's threat modeling framework
+
+### /autoresearch:ship — Universal Shipping Workflow (v1.1.0)
+
+Ship anything — code, content, marketing, sales, research, or design — through a structured 8-phase workflow that applies autoresearch loop principles to the last mile.
+
+Load: `references/ship-workflow.md` for full protocol.
+
+**What it does:**
+
+1. **Identify** — auto-detect what you're shipping (code PR, deployment, blog post, email campaign, sales deck, research paper, design assets)
+2. **Inventory** — assess current state and readiness gaps
+3. **Checklist** — generate domain-specific pre-ship gates (all mechanically verifiable)
+4. **Prepare** — autoresearch loop to fix failing checklist items until 100% pass
+5. **Dry-run** — simulate the ship action without side effects
+6. **Ship** — execute the actual delivery (merge, deploy, publish, send)
+7. **Verify** — post-ship health check confirms it landed
+8. **Log** — record shipment to `ship-log.tsv` for traceability
+
+**Supported shipment types:**
+
+| Type | Example Ship Actions |
+|------|---------------------|
+| `code-pr` | `gh pr create` with full description |
+| `code-release` | Git tag + GitHub release |
+| `deployment` | CI/CD trigger, `kubectl apply`, push to deploy branch |
+| `content` | Publish via CMS, commit to content branch |
+| `marketing-email` | Send via ESP (SendGrid, Mailchimp) |
+| `marketing-campaign` | Activate ads, launch landing page |
+| `sales` | Send proposal, share deck |
+| `research` | Upload to repository, submit paper |
+| `design` | Export assets, share with stakeholders |
+
+**Flags:**
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Validate everything but don't actually ship (stop at Phase 5) |
+| `--auto` | Auto-approve dry-run gate if no errors |
+| `--force` | Skip non-critical checklist items (blockers still enforced) |
+| `--rollback` | Undo the last ship action (if reversible) |
+| `--monitor N` | Post-ship monitoring for N minutes |
+| `--type <type>` | Override auto-detection with explicit shipment type |
+| `--checklist-only` | Only generate and evaluate checklist (stop at Phase 3) |
+
+**Usage:**
+```
+# Auto-detect and ship (interactive)
+/autoresearch:ship
+
+# Ship code PR with auto-approve
+/autoresearch:ship --auto
+
+# Dry-run a deployment before going live
+/autoresearch:ship --type deployment --dry-run
+
+# Ship with post-deployment monitoring
+/autoresearch:ship --monitor 10
+
+# Prepare iteratively then ship
+/loop 5 /autoresearch:ship
+
+# Just check if something is ready to ship
+/autoresearch:ship --checklist-only
+
+# Ship a blog post
+/autoresearch:ship
+Target: content/blog/my-new-post.md
+Type: content
+
+# Ship a sales deck
+/autoresearch:ship --type sales
+Target: decks/q1-proposal.pdf
+
+# Rollback a bad deployment
+/autoresearch:ship --rollback
+```
+
+**Composite metric (for bounded loops):**
+```
+ship_score = (checklist_passing / checklist_total) * 80
+           + (dry_run_passed ? 15 : 0)
+           + (no_blockers ? 5 : 0)
+```
+Score of 100 = fully ready. Below 80 = not shippable.
+
+**Output directory:** Creates `ship/{YYMMDD}-{HHMM}-{ship-slug}/` with `checklist.md`, `ship-log.tsv`, `summary.md`.
+
+### /autoresearch:plan — Goal → Configuration Wizard
+
+Converts a plain-language goal into a validated, ready-to-execute autoresearch configuration.
+
+Load: `references/plan-workflow.md` for full protocol.
+
+**Quick summary:**
+
+1. **Capture Goal** — ask what the user wants to improve (or accept inline text)
+2. **Analyze Context** — scan codebase for tooling, test runners, build scripts
+3. **Define Scope** — suggest file globs, validate they resolve to real files
+4. **Define Metric** — suggest mechanical metrics, validate they output a number
+5. **Define Direction** — higher or lower is better
+6. **Define Verify** — construct the shell command, **dry-run it**, confirm it works
+7. **Confirm & Launch** — present the complete config, offer to launch immediately
+
+**Critical gates:**
+- Metric MUST be mechanical (outputs a parseable number, not subjective)
+- Verify command MUST pass a dry run on the current codebase before accepting
+- Scope MUST resolve to ≥1 file
+
+**Usage:**
+```
+/autoresearch:plan
+Goal: Make the API respond faster
+
+/autoresearch:plan Increase test coverage to 95%
+
+/autoresearch:plan Reduce bundle size below 200KB
+```
+
+After the wizard completes, the user gets a ready-to-paste `/autoresearch` invocation — or can launch it directly.
+
+## When to Activate
+
+- User invokes `/autoresearch` or `/ug:autoresearch` → run the loop
+- User invokes `/autoresearch:plan` → run the planning wizard
+- User invokes `/autoresearch:security` → run the security audit
+- User says "help me set up autoresearch", "plan an autoresearch run" → run the planning wizard
+- User says "security audit", "threat model", "OWASP", "STRIDE", "find vulnerabilities", "red-team" → run the security audit
+- User invokes `/autoresearch:ship` → run the ship workflow
+- User says "ship it", "deploy this", "publish this", "launch this", "get this out the door" → run the ship workflow
+- User says "work autonomously", "iterate until done", "keep improving", "run overnight" → run the loop
+- Any task requiring repeated iteration cycles with measurable outcomes → run the loop
+
+## Optional: Controlled Loop Count
+
+By default, autoresearch loops **forever** until manually interrupted. However, users can optionally specify a **loop count** to limit iterations using Claude Code's built-in `/loop` command.
+
+> **Requires:** Claude Code v1.0.32+ (the `/loop` command was introduced in this version)
+
+### Usage
+
+**Unlimited (default):**
+```
+/autoresearch
+Goal: Increase test coverage to 90%
+```
+
+**Bounded (N iterations):**
+```
+/loop 25 /autoresearch
+Goal: Increase test coverage to 90%
+```
+
+This chains `/autoresearch` with `/loop 25`, running exactly 25 iteration cycles. After 25 iterations, Claude stops and prints a final summary.
+
+### When to Use Bounded Loops
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Run overnight, review in morning | Unlimited (default) |
+| Quick 30-min improvement session | `/loop 10 /autoresearch` |
+| Targeted fix with known scope | `/loop 5 /autoresearch` |
+| Exploratory — see if approach works | `/loop 15 /autoresearch` |
+| CI/CD pipeline integration | `/loop N /autoresearch` (set N based on time budget) |
+
+### Behavior with Loop Count
+
+When a loop count is specified:
+- Claude runs exactly N iterations through the autoresearch loop
+- After iteration N, Claude prints a **final summary** with baseline → current best, keeps/discards/crashes
+- If the goal is achieved before N iterations, Claude prints early completion and stops
+- All other rules (atomic changes, mechanical verification, auto-rollback) still apply
+
+## Setup Phase (Do Once)
+
+1. **Read all in-scope files** for full context before any modification
+2. **Define the goal** — What does "better" mean? Extract or ask for a mechanical metric:
+   - Code: tests pass, build succeeds, performance benchmark improves
+   - Content: word count target hit, SEO score improves, readability score
+   - Design: lighthouse score, accessibility audit passes
+   - If no metric exists → define one with user, or use simplest proxy (e.g. "compiles without errors")
+3. **Define scope constraints** — Which files can you modify? Which are read-only?
+4. **Define guard (optional)** — A command that must ALWAYS pass for a change to be kept. Use this to prevent regressions while optimizing the main metric (e.g., `npm test` must pass while optimizing benchmark time). If not specified, no guard is enforced.
+5. **Create a results log** — Track every iteration (see `references/results-logging.md`)
+6. **Establish baseline** — Run verification on current state AND guard (if set). Record as iteration #0
+7. **Confirm and go** — Show user the setup, get confirmation, then BEGIN THE LOOP
+
+## The Loop
+
+Read `references/autonomous-loop-protocol.md` for full protocol details.
+
+```
+LOOP (FOREVER or N times):
+  1. Review: Read current state + git history + results log
+  2. Ideate: Pick next change based on goal, past results, what hasn't been tried
+  3. Modify: Make ONE focused change to in-scope files
+  4. Commit: Git commit the change (before verification)
+  5. Verify: Run the mechanical metric (tests, build, benchmark, etc.)
+  6. Guard: If guard is set, run the guard command
+  7. Decide:
+     - IMPROVED + guard passed (or no guard) → Keep commit, log "keep", advance
+     - IMPROVED + guard FAILED → Revert, then try to rework the optimization
+       (max 2 attempts) so it improves the metric WITHOUT breaking the guard.
+       Never modify guard/test files — adapt the implementation instead.
+       If still failing → log "discard (guard failed)" and move on
+     - SAME/WORSE → Git revert, log "discard"
+     - CRASHED → Try to fix (max 3 attempts), else log "crash" and move on
+  8. Log: Record result in results log
+  9. Repeat: Go to step 1.
+     - If unbounded: NEVER STOP. NEVER ASK "should I continue?"
+     - If bounded (N): Stop after N iterations, print final summary
+```
+
+## Critical Rules
+
+1. **Loop until done** — Unbounded: loop until interrupted. Bounded: loop N times then summarize.
+2. **Read before write** — Always understand full context before modifying
+3. **One change per iteration** — Atomic changes. If it breaks, you know exactly why
+4. **Mechanical verification only** — No subjective "looks good". Use metrics
+5. **Automatic rollback** — Failed changes revert instantly. No debates
+6. **Simplicity wins** — Equal results + less code = KEEP. Tiny improvement + ugly complexity = DISCARD
+7. **Git is memory** — Every kept change committed. Agent reads history to learn patterns
+8. **When stuck, think harder** — Re-read files, re-read goal, combine near-misses, try radical changes. Don't ask for help unless truly blocked by missing access/permissions
+
+## Principles Reference
+
+See `references/core-principles.md` for the 7 generalizable principles from autoresearch.
+
+## Adapting to Different Domains
+
+| Domain | Metric | Scope | Verify Command | Guard |
+|--------|--------|-------|----------------|-------|
+| Backend code | Tests pass + coverage % | `src/**/*.ts` | `npm test` | — |
+| Frontend UI | Lighthouse score | `src/components/**` | `npx lighthouse` | `npm test` |
+| ML training | val_bpb / loss | `train.py` | `uv run train.py` | — |
+| Blog/content | Word count + readability | `content/*.md` | Custom script | — |
+| Performance | Benchmark time (ms) | Target files | `npm run bench` | `npm test` |
+| Refactoring | Tests pass + LOC reduced | Target module | `npm test && wc -l` | `npm run typecheck` |
+| Security | OWASP + STRIDE coverage + findings | API/auth/middleware | `/autoresearch:security` | — |
+| Shipping | Checklist pass rate (%) | Any artifact | `/autoresearch:ship` | Domain-specific |
+
+Adapt the loop to your domain. The PRINCIPLES are universal; the METRICS are domain-specific.

--- a/.claude/skills/autoresearch/references/ship-workflow.md
+++ b/.claude/skills/autoresearch/references/ship-workflow.md
@@ -1,0 +1,393 @@
+# Ship Workflow — /autoresearch:ship
+
+Universal shipping workflow that applies autoresearch loop principles to the last mile — taking anything from "done" to "deployed/published/delivered." Works for code, content, marketing, sales, research, design, or any artifact that needs to reach its audience.
+
+**Core idea:** Shipping has a universal pattern regardless of domain. Identify → Checklist → Prepare → Dry-run → Ship → Verify → Log.
+
+## Trigger
+
+- User invokes `/autoresearch:ship`
+- User says "ship it", "deploy this", "publish this", "launch this", "release this"
+- User says "get this out the door", "push to prod", "send this out", "go live"
+
+## Loop Support
+
+Works with bounded mode for iterative pre-ship preparation:
+
+```
+# Ship with automatic preparation loop
+/autoresearch:ship
+
+# Bounded preparation — iterate N times before shipping
+/loop 10 /autoresearch:ship
+
+# Ship specific artifact
+/autoresearch:ship
+Target: src/features/auth/**
+Destination: production
+```
+
+## Architecture
+
+```
+/autoresearch:ship
+  ├── Phase 1: Identify (what are we shipping?)
+  ├── Phase 2: Inventory (what's the current state?)
+  ├── Phase 3: Checklist (domain-specific pre-ship gates)
+  ├── Phase 4: Prepare (autoresearch loop until checklist passes)
+  ├── Phase 5: Dry-run (simulate the ship action)
+  ├── Phase 6: Ship (execute the actual delivery)
+  ├── Phase 7: Verify (post-ship health check)
+  └── Phase 8: Log (record the shipment)
+```
+
+## Phase 1: Identify — What Are We Shipping?
+
+Auto-detect the shipment type from context, or ask the user.
+
+**Detection algorithm:**
+```
+FUNCTION detectShipmentType(context):
+  # Check explicit user input first
+  IF user specifies type → USE IT
+
+  # Auto-detect from context
+  IF git diff has staged changes OR user mentions "deploy/release/merge":
+    IF has Dockerfile/k8s/deploy configs → "deployment"
+    IF has open PR or branch changes → "code-pr"
+    ELSE → "code-release"
+
+  IF context mentions "blog/article/post" OR target files are *.md in content/:
+    → "content"
+
+  IF context mentions "email/campaign/newsletter":
+    → "marketing-email"
+
+  IF context mentions "landing page/ad/social":
+    → "marketing-campaign"
+
+  IF context mentions "deck/proposal/pitch/quote":
+    → "sales"
+
+  IF context mentions "paper/report/analysis/findings":
+    → "research"
+
+  IF context mentions "assets/mockup/design/figma":
+    → "design"
+
+  # Default: ask user
+  → ASK "What are you shipping? (code/content/marketing/sales/research/design/other)"
+```
+
+**Output:** `✓ Phase 1: Identified shipment — [type]: [brief description]`
+
+## Phase 2: Inventory — Current State Assessment
+
+Scan the artifact and its environment to understand readiness.
+
+**For each shipment type, gather:**
+
+| Type | Inventory Checks |
+|------|-----------------|
+| code-pr | Changed files, test status, lint status, PR description, review status |
+| code-release | Version tag, changelog, migration status, dependency audit |
+| deployment | Build status, env vars, infra health, rollback plan |
+| content | Word count, links checked, images present, metadata/frontmatter |
+| marketing-email | Subject line, preview text, links, unsubscribe, CAN-SPAM compliance |
+| marketing-campaign | Assets ready, tracking pixels, UTM params, A/B variants |
+| sales | Pricing current, branding consistent, contact info, CTA clear |
+| research | Citations complete, methodology documented, data sources linked |
+| design | Formats exported, responsive variants, accessibility checked |
+
+**Output:** `✓ Phase 2: Inventory complete — [N] items assessed, [M] gaps found`
+
+## Phase 3: Checklist — Domain-Specific Pre-Ship Gates
+
+Generate a mechanical checklist based on shipment type. Every item must be verifiable (pass/fail).
+
+### Code Checklists
+
+**code-pr:**
+- [ ] All tests pass (`npm test` / `pytest` / language-specific)
+- [ ] Lint clean (no errors, warnings acceptable)
+- [ ] Type check passes (if applicable)
+- [ ] PR description explains the "why"
+- [ ] No secrets in diff (`git diff --cached | grep -i "password\|secret\|api_key"`)
+- [ ] No TODO/FIXME in new code (or documented as intentional)
+- [ ] Breaking changes documented (if any)
+- [ ] Reviewer assigned or review complete
+
+**code-release:**
+- [ ] All code-pr checks pass
+- [ ] Version bumped in package.json/pyproject.toml/Cargo.toml
+- [ ] CHANGELOG updated with release notes
+- [ ] Migration scripts tested (if DB changes)
+- [ ] Dependency audit clean (`npm audit` / `pip audit`)
+- [ ] Tag created matching version
+
+**deployment:**
+- [ ] All code-release checks pass
+- [ ] Build succeeds in CI
+- [ ] Environment variables set for target env
+- [ ] Health check endpoint responds
+- [ ] Rollback plan documented
+- [ ] Monitoring/alerting configured
+- [ ] Feature flags set correctly
+
+### Content Checklists
+
+**content (blog/docs):**
+- [ ] Title present and descriptive
+- [ ] No broken links (internal or external)
+- [ ] Images have alt text
+- [ ] Meta description present (≤160 chars)
+- [ ] No placeholder text ("Lorem ipsum", "TODO", "TBD")
+- [ ] Grammar/spell check passes
+- [ ] Publish date set
+- [ ] Author attribution present
+
+### Marketing Checklists
+
+**marketing-email:**
+- [ ] Subject line present (≤60 chars recommended)
+- [ ] Preview text set
+- [ ] All links working and tracked (UTM parameters)
+- [ ] Unsubscribe link present and functional
+- [ ] Physical address included (CAN-SPAM)
+- [ ] Responsive on mobile (test render)
+- [ ] Plain text fallback exists
+- [ ] Sender name and reply-to configured
+
+**marketing-campaign:**
+- [ ] All creative assets finalized
+- [ ] Tracking pixels/UTM parameters configured
+- [ ] Target audience defined and segmented
+- [ ] Budget allocated and approved
+- [ ] Landing page live and tested
+- [ ] A/B test variants set (if applicable)
+- [ ] Schedule confirmed
+
+### Sales Checklists
+
+**sales (deck/proposal):**
+- [ ] Company/prospect name correct throughout
+- [ ] Pricing is current and approved
+- [ ] Contact information accurate
+- [ ] Branding consistent (logos, colors, fonts)
+- [ ] No competitor names misspelled
+- [ ] CTA is clear and actionable
+- [ ] Attached case studies/testimonials current
+- [ ] File format appropriate (PDF for external, editable for internal)
+
+### Research Checklists
+
+**research (paper/report):**
+- [ ] Abstract/executive summary present
+- [ ] All citations properly formatted
+- [ ] Data sources linked and accessible
+- [ ] Methodology section complete
+- [ ] Figures/charts labeled and referenced
+- [ ] Conclusion addresses stated hypothesis
+- [ ] Acknowledgments included
+- [ ] No placeholder references ("[citation needed]")
+
+### Design Checklists
+
+**design (assets/mockups):**
+- [ ] All requested formats exported (PNG, SVG, PDF)
+- [ ] Responsive variants provided (mobile, tablet, desktop)
+- [ ] Color contrast meets WCAG AA (4.5:1 for text)
+- [ ] No placeholder images or text
+- [ ] Source files organized and named
+- [ ] Brand guidelines followed
+- [ ] Handoff notes/specs documented
+
+**Output:** `✓ Phase 3: Checklist generated — [N] items, [P] passing, [F] failing`
+
+## Phase 4: Prepare — Iterative Improvement Loop
+
+Apply the autoresearch loop to fix failing checklist items.
+
+```
+metric = count_passing_checklist_items / total_checklist_items * 100
+direction = higher_is_better
+target = 100 (all items pass)
+
+LOOP (until all pass OR max iterations):
+  1. Read checklist status
+  2. Pick highest-priority failing item
+  3. Fix it (one atomic change)
+  4. Re-run checklist verification
+  5. IF item now passes → keep, log "fixed: [item]"
+  6. IF item still fails → revert, try different approach
+  7. IF all items pass → EXIT LOOP with "ready to ship"
+```
+
+**Priority order for fixes:**
+1. **Blockers** — security issues, broken builds, missing critical content
+2. **Required** — tests, lint, links, compliance items
+3. **Recommended** — descriptions, documentation, polish
+
+**Auto-fix capabilities:**
+- Run test suites and fix failures
+- Fix lint errors automatically
+- Add missing meta descriptions
+- Generate changelog entries from git log
+- Check and fix broken links
+- Add alt text to images (describe or prompt user)
+- Format citations
+- Export missing design formats
+
+**Items that require human input:**
+- Pricing approval
+- Legal review sign-off
+- Brand approval
+- Strategic decisions (A/B test variants)
+- → Flag these and ask user, don't block on them
+
+**Output:** `✓ Phase 4: Preparation complete — [N/N] checklist items passing`
+
+## Phase 5: Dry-Run — Simulate Before Shipping
+
+Execute a simulation of the ship action without side effects.
+
+| Type | Dry-Run Action |
+|------|---------------|
+| code-pr | `gh pr create --draft` or preview PR diff |
+| code-release | Create tag locally (don't push), preview changelog |
+| deployment | Build Docker image, run health checks locally |
+| content | Preview render, check all links resolve |
+| marketing-email | Send test email to sender's own address |
+| marketing-campaign | Preview in ad platform, estimate reach |
+| sales | Preview PDF render, check all pages |
+| research | Export to final format, check pagination |
+| design | Preview all exported formats, check dimensions |
+
+**Dry-run gate:**
+- Present dry-run results to user
+- `--auto` flag: auto-approve if no errors
+- Default: ask user "Ready to ship?" before proceeding
+- `--dry-run` flag: stop here, don't actually ship
+
+**Output:** `✓ Phase 5: Dry-run complete — [result summary]`
+
+## Phase 6: Ship — Execute the Delivery
+
+The actual ship action. Domain-specific.
+
+| Type | Ship Action |
+|------|------------|
+| code-pr | `gh pr create` with full description, request reviewers |
+| code-release | `git tag`, `git push --tags`, create GitHub release |
+| deployment | `git push` to deploy branch, trigger CI/CD, or `kubectl apply` |
+| content | Publish via CMS API, or commit to content branch |
+| marketing-email | Send via ESP API (SendGrid, Mailchimp, etc.) |
+| marketing-campaign | Activate campaign in ad platform |
+| sales | Send email with attachment, or share link |
+| research | Upload to repository, submit to journal/platform |
+| design | Upload to asset library, share with stakeholders |
+
+**Safety rails:**
+- Confirm target (staging vs production, draft vs publish)
+- Log the exact command/action taken
+- Record timestamp
+- Capture any response/confirmation IDs
+
+**Output:** `✓ Phase 6: Shipped — [action taken] at [timestamp]`
+
+## Phase 7: Verify — Post-Ship Health Check
+
+Confirm the shipment actually landed and is healthy.
+
+| Type | Verification |
+|------|-------------|
+| code-pr | PR created, CI running, link accessible |
+| code-release | Tag visible, release page published, assets attached |
+| deployment | Health endpoint returns 200, no error spike in logs |
+| content | Page loads, links work, appears in sitemap |
+| marketing-email | Delivery rate > 95%, no bounce spike |
+| marketing-campaign | Ads serving, landing page loading, tracking firing |
+| sales | Email delivered, link tracking active |
+| research | Accessible via URL/DOI, properly indexed |
+| design | Assets downloadable, correct dimensions |
+
+**Post-ship monitoring (with `--monitor N` flag):**
+```
+FOR N minutes:
+  Check health metrics every 60 seconds
+  IF anomaly detected → ALERT user immediately
+  Log metrics to ship-log
+```
+
+**Output:** `✓ Phase 7: Verified — [health status summary]`
+
+## Phase 8: Log — Record the Shipment
+
+Create a ship log entry for traceability.
+
+**Log format (append to `ship-log.tsv`):**
+```tsv
+timestamp	type	target	checklist_score	dry_run	shipped	verified	duration	notes
+2026-03-16T14:30:00Z	code-pr	#42	18/18	pass	pass	pass	4m32s	auth feature PR
+```
+
+**Summary output:**
+```
+=== Ship Complete ===
+Type: [shipment type]
+Target: [where it went]
+Checklist: [P/T] items passed
+Duration: [total time]
+Status: SHIPPED ✓
+```
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Run all phases except actual ship (stop at Phase 5) |
+| `--auto` | Auto-approve dry-run gate if no errors found |
+| `--force` | Skip non-critical checklist items (still enforce blockers) |
+| `--rollback` | Undo the last ship action (if reversible) |
+| `--monitor N` | Post-ship monitoring for N minutes |
+| `--type <type>` | Override auto-detection with explicit shipment type |
+| `--checklist-only` | Only generate and evaluate checklist (stop at Phase 3) |
+
+## Composite Metric
+
+For bounded loop mode, the ship readiness metric:
+
+```
+ship_score = (checklist_passing / checklist_total) * 80
+           + (dry_run_passed ? 15 : 0)
+           + (no_blockers ? 5 : 0)
+```
+
+- **100** = fully ready to ship
+- **80-99** = ready with minor items (can ship with `--force`)
+- **<80** = not ready, continue preparing
+
+## Rollback Protocol
+
+If `--rollback` is specified or post-ship verification fails:
+
+| Type | Rollback Action |
+|------|----------------|
+| code-pr | Close PR: `gh pr close` |
+| code-release | Delete tag: `git tag -d` + `git push --delete origin` |
+| deployment | Revert deploy: `git revert` or `kubectl rollback` |
+| content | Unpublish/revert to draft |
+| marketing-email | Cannot rollback (flag as "sent") |
+| marketing-campaign | Pause campaign in ad platform |
+| sales | Send correction/follow-up |
+| research | Request retraction or update |
+| design | Revert to previous version in asset library |
+
+**Non-reversible actions** (email, some publications) are flagged before Phase 6 ship action.
+
+## Output Directory
+
+Creates `ship/{YYMMDD}-{HHMM}-{ship-slug}/` with:
+- `checklist.md` — full checklist with pass/fail status
+- `ship-log.tsv` — iteration log (if preparation loop ran)
+- `summary.md` — final ship report


### PR DESCRIPTION
## Summary

- Adds `/autoresearch:ship` — a new subcommand that applies autoresearch loop principles to the **last mile of shipping anything**: code, content, marketing, sales, research, or design
- Bumps version from `1.0.4` → `1.1.0`
- Adds `references/ship-workflow.md` with the complete 8-phase protocol

## What is `/autoresearch:ship`?

A universal shipping workflow that takes any artifact from "done" to "deployed/published/delivered." It works because **shipping has a universal pattern regardless of domain:**

```
Identify → Inventory → Checklist → Prepare → Dry-run → Ship → Verify → Log
```

### The 8 Phases

| Phase | What it does |
|-------|-------------|
| **1. Identify** | Auto-detect what you're shipping (code PR, deployment, blog post, email campaign, sales deck, research paper, design assets) — or accept explicit `--type` |
| **2. Inventory** | Assess current state — changed files, test status, missing metadata, broken links, etc. |
| **3. Checklist** | Generate domain-specific pre-ship gates — every item is **mechanically verifiable** (pass/fail, no subjective "looks good") |
| **4. Prepare** | Apply the **autoresearch loop** to fix failing checklist items iteratively until 100% pass |
| **5. Dry-run** | Simulate the ship action without side effects (draft PR, test email, local build, preview render) |
| **6. Ship** | Execute the actual delivery — merge, deploy, publish, send |
| **7. Verify** | Post-ship health check — confirms the thing actually landed and is working |
| **8. Log** | Record shipment to `ship-log.tsv` with timestamp, type, checklist score, and duration |

### 9 Supported Shipment Types

| Type | Checklist Items | Ship Action | Post-Ship Verification |
|------|----------------|-------------|----------------------|
| `code-pr` | Tests pass, lint clean, no secrets, PR description | `gh pr create` | PR created, CI running |
| `code-release` | Version bumped, changelog, dependency audit | Git tag + GitHub release | Tag visible, release page live |
| `deployment` | Build succeeds, env vars set, rollback plan | CI/CD trigger or `kubectl apply` | Health endpoint 200, no error spike |
| `content` | No broken links, images have alt text, meta description | Publish via CMS or content branch | Page loads, in sitemap |
| `marketing-email` | Subject line, unsubscribe link, CAN-SPAM, responsive | Send via ESP (SendGrid, Mailchimp) | Delivery rate >95% |
| `marketing-campaign` | Assets finalized, UTM params, landing page live | Activate in ad platform | Ads serving, tracking firing |
| `sales` | Pricing current, branding consistent, CTA clear | Send email/share link | Email delivered, tracking active |
| `research` | Citations complete, methodology documented | Upload to repository | Accessible via URL/DOI |
| `design` | All formats exported, WCAG contrast, brand compliant | Upload to asset library | Assets downloadable |

### 7 Flags

| Flag | What it does |
|------|-------------|
| `--dry-run` | Run all phases except actual ship (stop at Phase 5) |
| `--auto` | Auto-approve dry-run gate if no errors found |
| `--force` | Skip non-critical checklist items (blockers still enforced) |
| `--rollback` | Undo the last ship action (if reversible) |
| `--monitor N` | Post-ship monitoring for N minutes |
| `--type <type>` | Override auto-detection with explicit shipment type |
| `--checklist-only` | Only generate and evaluate checklist (stop at Phase 3) |

## How to Use `/autoresearch:ship`

### Basic — Ship Code PR
```bash
# Auto-detect and ship (walks you through interactively)
/autoresearch:ship

# Auto-approve everything if checklist passes
/autoresearch:ship --auto
```

### Ship a Deployment
```bash
# Dry-run first, then ship
/autoresearch:ship --type deployment --dry-run
# If looks good:
/autoresearch:ship --type deployment --auto

# With 10-minute post-deploy monitoring
/autoresearch:ship --type deployment --monitor 10
```

### Ship Content (Blog Post)
```bash
/autoresearch:ship
Target: content/blog/my-new-post.md
Type: content
```

### Ship Marketing Email
```bash
/autoresearch:ship --type marketing-email
Target: campaigns/march-newsletter.html
```

### Ship Sales Deck
```bash
/autoresearch:ship --type sales
Target: decks/q1-enterprise-proposal.pdf
```

### Iterate Before Shipping
```bash
# Run 5 preparation iterations, fixing checklist items each time
/loop 5 /autoresearch:ship
```

### Just Check Readiness
```bash
# Generate checklist without shipping — great for pre-flight checks
/autoresearch:ship --checklist-only
```

### Rollback a Bad Ship
```bash
/autoresearch:ship --rollback
```

## Composite Readiness Metric

For bounded loop mode (`/loop N /autoresearch:ship`), the ship readiness score:

```
ship_score = (checklist_passing / checklist_total) * 80
           + (dry_run_passed ? 15 : 0)
           + (no_blockers ? 5 : 0)
```

- **100** = fully ready to ship
- **80-99** = ready with minor items (can ship with `--force`)
- **<80** = not ready, keep preparing

## Design Philosophy

1. **Domain-agnostic** — same 8-phase pattern for code, content, marketing, sales, research, design
2. **Mechanical verification** — every checklist item is pass/fail, no subjective "looks good"
3. **Autoresearch loop for preparation** — iteratively fix failing items until 100% pass
4. **Dry-run before real ship** — simulate without side effects
5. **Rollback capability** — undo reversible actions, flag irreversible ones before execution
6. **Evidence-based** — every ship action requires proof of readiness, post-ship verification confirms landing
7. **Traceable** — `ship-log.tsv` records every shipment for audit trail

## Files Changed

- `SKILL.md` — Added ship subcommand to subcommands table, full documentation section, activation triggers, domain adaptation table entry, version bump 1.0.4 → 1.1.0
- `references/ship-workflow.md` — Complete 8-phase protocol with detection algorithm, domain-specific checklists (7 domains, 50+ checklist items), preparation loop, dry-run actions, ship actions, verification checks, rollback protocol, composite metric, output directory structure

## Test plan

- [ ] Invoke `/autoresearch:ship` and verify auto-detection works for code context (staged git changes)
- [ ] Invoke `/autoresearch:ship --checklist-only` and verify domain-specific checklist generates
- [ ] Invoke `/autoresearch:ship --dry-run` and verify it stops before actual ship action
- [ ] Invoke `/autoresearch:ship --type content` with a markdown file and verify content checklist
- [ ] Verify `--rollback` flag is recognized and routes to rollback protocol
- [ ] Test bounded mode: `/loop 3 /autoresearch:ship` iterates preparation and reports composite score
- [ ] Verify SKILL.md subcommand table has 4 entries (autoresearch, plan, security, ship)