### PR TITLE
fix: register autoresearch subcommands as command files

### DIFF
--- a/.claude/commands/autoresearch/plan.md
+++ b/.claude/commands/autoresearch/plan.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:plan
+description: Interactive wizard to build Scope, Metric, Direction & Verify from a Goal
+argument-hint: "[goal description]"
+---
+
+Load and follow the autoresearch plan workflow protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the plan workflow reference: `.claude/skills/autoresearch/references/plan-workflow.md` — this is the FULL protocol to follow
+3. Accept the user's goal from arguments: $ARGUMENTS
+4. Execute the 7-step planning wizard as defined in `plan-workflow.md`
+
+Follow the plan workflow protocol exactly. All gates (mechanical metric, dry-run, scope resolution) must pass before accepting.

--- a/.claude/commands/autoresearch/security.md
+++ b/.claude/commands/autoresearch/security.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:security
+description: Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas
+argument-hint: "[--diff] [--fix] [--fail-on <severity>]"
+---
+
+Load and follow the autoresearch security audit protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the security workflow reference: `.claude/skills/autoresearch/references/security-workflow.md` — this is the FULL protocol to follow
+3. Parse any flags from the user's arguments: $ARGUMENTS
+4. Execute the 7-step security audit as defined in `security-workflow.md`
+
+Follow the security workflow protocol exactly. Every finding requires code evidence (file:line + attack scenario). Track OWASP Top 10 + STRIDE coverage.

--- a/.claude/commands/autoresearch/ship.md
+++ b/.claude/commands/autoresearch/ship.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:ship
+description: Universal shipping workflow — ship code, content, marketing, sales, research, or anything through structured 8-phase workflow
+argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--checklist-only]"
+---
+
+Load and follow the autoresearch ship workflow protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the ship workflow reference: `.claude/skills/autoresearch/references/ship-workflow.md` — this is the FULL protocol to follow
+3. Parse any flags from the user's arguments: $ARGUMENTS
+4. Execute the 8-phase ship workflow as defined in `ship-workflow.md`
+
+Follow the ship workflow protocol exactly. All phases, checklists, and verification steps must be executed as documented.


### PR DESCRIPTION
## Summary

- Fixes `/autoresearch:ship`, `/autoresearch:plan`, and `/autoresearch:security` returning "Unknown skill" error
- Adds command registration files in `.claude/commands/autoresearch/` — the mechanism Claude Code uses to resolve `parent:subcommand` syntax
- Each command file loads the corresponding reference workflow from the skill's `references/` directory

## Root Cause

PR #10 added the ship workflow as documentation in `SKILL.md` and `references/ship-workflow.md`, but never created the **command registration files**. Claude Code resolves subcommand syntax (`/parent:subcommand`) by looking for `.md` files in `.claude/commands/<parent>/<subcommand>.md` — the same pattern used by GSD (`~/.claude/commands/gsd/*.md`).

## Files Added

| File | Registers |
|------|-----------|
| `.claude/commands/autoresearch/ship.md` | `/autoresearch:ship` |
| `.claude/commands/autoresearch/plan.md` | `/autoresearch:plan` |
| `.claude/commands/autoresearch/security.md` | `/autoresearch:security` |

## Test plan

- [ ] Restart Claude Code session after merge
- [ ] Run `/autoresearch:ship` — should load ship workflow protocol
- [ ] Run `/autoresearch:plan` — should load plan wizard protocol
- [ ] Run `/autoresearch:security` — should load security audit protocol