### PR TITLE
feat: add Claude Code marketplace/plugin manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "autoresearch",
+  "version": "1.0.0",
+  "description": "Claude Autoresearch — autonomous goal-directed iteration for Claude Code. Inspired by Karpathy's autoresearch: constraint + mechanical metric + autonomous iteration = compounding gains.",
+  "owner": {
+    "name": "Udit Goenka",
+    "email": "udit@udit.co"
+  },
+  "plugins": [
+    {
+      "name": "autoresearch",
+      "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:security (STRIDE + OWASP audit), and /autoresearch:ship (multi-phase delivery workflow).",
+      "version": "1.0.0",
+      "author": {
+        "name": "Udit Goenka",
+        "email": "udit@udit.co"
+      },
+      "source": ".",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "autoresearch",
+  "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. Includes planning wizard, security audit, and shipping workflow.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Udit Goenka",
+    "email": "udit@udit.co"
+  }
+}


### PR DESCRIPTION
## What

Adds `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so this repo can be installed directly via the Claude Code plugin system.

## Why

Right now running `/plugin install https://github.com/uditgoenka/autoresearch` fails with:

```
Marketplace "https://github.com/uditgoenka/autoresearch" not found
```

Claude Code expects a `.claude-plugin/marketplace.json` at the repo root to discover plugins. Without it, the install command has nothing to parse.

## After this PR

```bash
# Add the marketplace
/plugin install autoresearch@autoresearch

# Or via settings.json
"extraKnownMarketplaces": {
  "autoresearch": {
    "source": { "source": "git", "url": "https://github.com/uditgoenka/autoresearch.git" }
  }
}
```

## Files added

| File | Purpose |
|---|---|
| `.claude-plugin/marketplace.json` | Marketplace manifest — registers this repo as a marketplace with one plugin |
| `.claude-plugin/plugin.json` | Plugin manifest — metadata for the `autoresearch` plugin itself |

The manifest follows the same schema as [`anthropics/claude-code`](https://github.com/anthropics/claude-code/blob/main/.claude-plugin/marketplace.json) and points `source: "."` so the existing `skills/autoresearch/` directory is picked up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)