### PR TITLE
fix: register subcommands and sync distributable skill (v1.1.1)

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.1.0
+version: 1.1.1
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — the principle that **constraint + mechanical metric + autonomous iteration = compounding gains**.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.1.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 
@@ -231,15 +231,19 @@ Clone this repo and copy the skill to your Claude Code skills directory:
 # Clone
 git clone https://github.com/uditgoenka/autoresearch.git
 
-# Copy to your project's Claude Code skills
+# Copy skill + subcommands to your project's Claude Code directory
 cp -r autoresearch/skills/autoresearch .claude/skills/autoresearch
+cp -r autoresearch/commands/autoresearch .claude/commands/autoresearch
 ```
 
-Or copy directly into your global skills:
+Or copy directly into your global config:
 
 ```bash
 cp -r autoresearch/skills/autoresearch ~/.claude/skills/autoresearch
+cp -r autoresearch/commands/autoresearch ~/.claude/commands/autoresearch
 ```
+
+> **Note:** The `commands/` directory is required for subcommands (`/autoresearch:ship`, `/autoresearch:plan`, `/autoresearch:security`) to be recognized by Claude Code. Without it, only `/autoresearch` will work.
 
 ### 2. Invoke It
 

--- a/commands/autoresearch/plan.md
+++ b/commands/autoresearch/plan.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:plan
+description: Interactive wizard to build Scope, Metric, Direction & Verify from a Goal
+argument-hint: "[goal description]"
+---
+
+Load and follow the autoresearch plan workflow protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the plan workflow reference: `.claude/skills/autoresearch/references/plan-workflow.md` — this is the FULL protocol to follow
+3. Accept the user's goal from arguments: $ARGUMENTS
+4. Execute the 7-step planning wizard as defined in `plan-workflow.md`
+
+Follow the plan workflow protocol exactly. All gates (mechanical metric, dry-run, scope resolution) must pass before accepting.

--- a/commands/autoresearch/security.md
+++ b/commands/autoresearch/security.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:security
+description: Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas
+argument-hint: "[--diff] [--fix] [--fail-on <severity>]"
+---
+
+Load and follow the autoresearch security audit protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the security workflow reference: `.claude/skills/autoresearch/references/security-workflow.md` — this is the FULL protocol to follow
+3. Parse any flags from the user's arguments: $ARGUMENTS
+4. Execute the 7-step security audit as defined in `security-workflow.md`
+
+Follow the security workflow protocol exactly. Every finding requires code evidence (file:line + attack scenario). Track OWASP Top 10 + STRIDE coverage.

--- a/commands/autoresearch/ship.md
+++ b/commands/autoresearch/ship.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:ship
+description: Universal shipping workflow — ship code, content, marketing, sales, research, or anything through structured 8-phase workflow
+argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--checklist-only]"
+---
+
+Load and follow the autoresearch ship workflow protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the ship workflow reference: `.claude/skills/autoresearch/references/ship-workflow.md` — this is the FULL protocol to follow
+3. Parse any flags from the user's arguments: $ARGUMENTS
+4. Execute the 8-phase ship workflow as defined in `ship-workflow.md`
+
+Follow the ship workflow protocol exactly. All phases, checklists, and verification steps must be executed as documented.

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.0.4
+version: 1.1.1
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
@@ -17,6 +17,7 @@ Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch).
 | `/autoresearch` | Run the autonomous loop (default) |
 | `/autoresearch:plan` | Interactive wizard to build Scope, Metric, Direction & Verify from a Goal |
 | `/autoresearch:security` | Autonomous security audit: STRIDE threat model + OWASP Top 10 + red-team (4 adversarial personas) |
+| `/autoresearch:ship` | Universal shipping workflow: ship code, content, marketing, sales, research, or anything |
 
 ### /autoresearch:security — Autonomous Security Audit (v1.0.3)
 
@@ -82,6 +83,92 @@ Focus: authentication and authorization flows
 - OWASP Top 10 (2021) — industry-standard vulnerability taxonomy
 - STRIDE — Microsoft's threat modeling framework
 
+### /autoresearch:ship — Universal Shipping Workflow (v1.1.0)
+
+Ship anything — code, content, marketing, sales, research, or design — through a structured 8-phase workflow that applies autoresearch loop principles to the last mile.
+
+Load: `references/ship-workflow.md` for full protocol.
+
+**What it does:**
+
+1. **Identify** — auto-detect what you're shipping (code PR, deployment, blog post, email campaign, sales deck, research paper, design assets)
+2. **Inventory** — assess current state and readiness gaps
+3. **Checklist** — generate domain-specific pre-ship gates (all mechanically verifiable)
+4. **Prepare** — autoresearch loop to fix failing checklist items until 100% pass
+5. **Dry-run** — simulate the ship action without side effects
+6. **Ship** — execute the actual delivery (merge, deploy, publish, send)
+7. **Verify** — post-ship health check confirms it landed
+8. **Log** — record shipment to `ship-log.tsv` for traceability
+
+**Supported shipment types:**
+
+| Type | Example Ship Actions |
+|------|---------------------|
+| `code-pr` | `gh pr create` with full description |
+| `code-release` | Git tag + GitHub release |
+| `deployment` | CI/CD trigger, `kubectl apply`, push to deploy branch |
+| `content` | Publish via CMS, commit to content branch |
+| `marketing-email` | Send via ESP (SendGrid, Mailchimp) |
+| `marketing-campaign` | Activate ads, launch landing page |
+| `sales` | Send proposal, share deck |
+| `research` | Upload to repository, submit paper |
+| `design` | Export assets, share with stakeholders |
+
+**Flags:**
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Validate everything but don't actually ship (stop at Phase 5) |
+| `--auto` | Auto-approve dry-run gate if no errors |
+| `--force` | Skip non-critical checklist items (blockers still enforced) |
+| `--rollback` | Undo the last ship action (if reversible) |
+| `--monitor N` | Post-ship monitoring for N minutes |
+| `--type <type>` | Override auto-detection with explicit shipment type |
+| `--checklist-only` | Only generate and evaluate checklist (stop at Phase 3) |
+
+**Usage:**
+```
+# Auto-detect and ship (interactive)
+/autoresearch:ship
+
+# Ship code PR with auto-approve
+/autoresearch:ship --auto
+
+# Dry-run a deployment before going live
+/autoresearch:ship --type deployment --dry-run
+
+# Ship with post-deployment monitoring
+/autoresearch:ship --monitor 10
+
+# Prepare iteratively then ship
+/loop 5 /autoresearch:ship
+
+# Just check if something is ready to ship
+/autoresearch:ship --checklist-only
+
+# Ship a blog post
+/autoresearch:ship
+Target: content/blog/my-new-post.md
+Type: content
+
+# Ship a sales deck
+/autoresearch:ship --type sales
+Target: decks/q1-proposal.pdf
+
+# Rollback a bad deployment
+/autoresearch:ship --rollback
+```
+
+**Composite metric (for bounded loops):**
+```
+ship_score = (checklist_passing / checklist_total) * 80
+           + (dry_run_passed ? 15 : 0)
+           + (no_blockers ? 5 : 0)
+```
+Score of 100 = fully ready. Below 80 = not shippable.
+
+**Output directory:** Creates `ship/{YYMMDD}-{HHMM}-{ship-slug}/` with `checklist.md`, `ship-log.tsv`, `summary.md`.
+
 ### /autoresearch:plan — Goal → Configuration Wizard
 
 Converts a plain-language goal into a validated, ready-to-execute autoresearch configuration.
@@ -122,6 +209,8 @@ After the wizard completes, the user gets a ready-to-paste `/autoresearch` invoc
 - User invokes `/autoresearch:security` → run the security audit
 - User says "help me set up autoresearch", "plan an autoresearch run" → run the planning wizard
 - User says "security audit", "threat model", "OWASP", "STRIDE", "find vulnerabilities", "red-team" → run the security audit
+- User invokes `/autoresearch:ship` → run the ship workflow
+- User says "ship it", "deploy this", "publish this", "launch this", "get this out the door" → run the ship workflow
 - User says "work autonomously", "iterate until done", "keep improving", "run overnight" → run the loop
 - Any task requiring repeated iteration cycles with measurable outcomes → run the loop
 
@@ -231,5 +320,6 @@ See `references/core-principles.md` for the 7 generalizable principles from auto
 | Performance | Benchmark time (ms) | Target files | `npm run bench` | `npm test` |
 | Refactoring | Tests pass + LOC reduced | Target module | `npm test && wc -l` | `npm run typecheck` |
 | Security | OWASP + STRIDE coverage + findings | API/auth/middleware | `/autoresearch:security` | — |
+| Shipping | Checklist pass rate (%) | Any artifact | `/autoresearch:ship` | Domain-specific |
 
 Adapt the loop to your domain. The PRINCIPLES are universal; the METRICS are domain-specific.

--- a/skills/autoresearch/references/ship-workflow.md
+++ b/skills/autoresearch/references/ship-workflow.md
@@ -1,0 +1,393 @@
+# Ship Workflow — /autoresearch:ship
+
+Universal shipping workflow that applies autoresearch loop principles to the last mile — taking anything from "done" to "deployed/published/delivered." Works for code, content, marketing, sales, research, design, or any artifact that needs to reach its audience.
+
+**Core idea:** Shipping has a universal pattern regardless of domain. Identify → Checklist → Prepare → Dry-run → Ship → Verify → Log.
+
+## Trigger
+
+- User invokes `/autoresearch:ship`
+- User says "ship it", "deploy this", "publish this", "launch this", "release this"
+- User says "get this out the door", "push to prod", "send this out", "go live"
+
+## Loop Support
+
+Works with bounded mode for iterative pre-ship preparation:
+
+```
+# Ship with automatic preparation loop
+/autoresearch:ship
+
+# Bounded preparation — iterate N times before shipping
+/loop 10 /autoresearch:ship
+
+# Ship specific artifact
+/autoresearch:ship
+Target: src/features/auth/**
+Destination: production
+```
+
+## Architecture
+
+```
+/autoresearch:ship
+  ├── Phase 1: Identify (what are we shipping?)
+  ├── Phase 2: Inventory (what's the current state?)
+  ├── Phase 3: Checklist (domain-specific pre-ship gates)
+  ├── Phase 4: Prepare (autoresearch loop until checklist passes)
+  ├── Phase 5: Dry-run (simulate the ship action)
+  ├── Phase 6: Ship (execute the actual delivery)
+  ├── Phase 7: Verify (post-ship health check)
+  └── Phase 8: Log (record the shipment)
+```
+
+## Phase 1: Identify — What Are We Shipping?
+
+Auto-detect the shipment type from context, or ask the user.
+
+**Detection algorithm:**
+```
+FUNCTION detectShipmentType(context):
+  # Check explicit user input first
+  IF user specifies type → USE IT
+
+  # Auto-detect from context
+  IF git diff has staged changes OR user mentions "deploy/release/merge":
+    IF has Dockerfile/k8s/deploy configs → "deployment"
+    IF has open PR or branch changes → "code-pr"
+    ELSE → "code-release"
+
+  IF context mentions "blog/article/post" OR target files are *.md in content/:
+    → "content"
+
+  IF context mentions "email/campaign/newsletter":
+    → "marketing-email"
+
+  IF context mentions "landing page/ad/social":
+    → "marketing-campaign"
+
+  IF context mentions "deck/proposal/pitch/quote":
+    → "sales"
+
+  IF context mentions "paper/report/analysis/findings":
+    → "research"
+
+  IF context mentions "assets/mockup/design/figma":
+    → "design"
+
+  # Default: ask user
+  → ASK "What are you shipping? (code/content/marketing/sales/research/design/other)"
+```
+
+**Output:** `✓ Phase 1: Identified shipment — [type]: [brief description]`
+
+## Phase 2: Inventory — Current State Assessment
+
+Scan the artifact and its environment to understand readiness.
+
+**For each shipment type, gather:**
+
+| Type | Inventory Checks |
+|------|-----------------|
+| code-pr | Changed files, test status, lint status, PR description, review status |
+| code-release | Version tag, changelog, migration status, dependency audit |
+| deployment | Build status, env vars, infra health, rollback plan |
+| content | Word count, links checked, images present, metadata/frontmatter |
+| marketing-email | Subject line, preview text, links, unsubscribe, CAN-SPAM compliance |
+| marketing-campaign | Assets ready, tracking pixels, UTM params, A/B variants |
+| sales | Pricing current, branding consistent, contact info, CTA clear |
+| research | Citations complete, methodology documented, data sources linked |
+| design | Formats exported, responsive variants, accessibility checked |
+
+**Output:** `✓ Phase 2: Inventory complete — [N] items assessed, [M] gaps found`
+
+## Phase 3: Checklist — Domain-Specific Pre-Ship Gates
+
+Generate a mechanical checklist based on shipment type. Every item must be verifiable (pass/fail).
+
+### Code Checklists
+
+**code-pr:**
+- [ ] All tests pass (`npm test` / `pytest` / language-specific)
+- [ ] Lint clean (no errors, warnings acceptable)
+- [ ] Type check passes (if applicable)
+- [ ] PR description explains the "why"
+- [ ] No secrets in diff (`git diff --cached | grep -i "password\|secret\|api_key"`)
+- [ ] No TODO/FIXME in new code (or documented as intentional)
+- [ ] Breaking changes documented (if any)
+- [ ] Reviewer assigned or review complete
+
+**code-release:**
+- [ ] All code-pr checks pass
+- [ ] Version bumped in package.json/pyproject.toml/Cargo.toml
+- [ ] CHANGELOG updated with release notes
+- [ ] Migration scripts tested (if DB changes)
+- [ ] Dependency audit clean (`npm audit` / `pip audit`)
+- [ ] Tag created matching version
+
+**deployment:**
+- [ ] All code-release checks pass
+- [ ] Build succeeds in CI
+- [ ] Environment variables set for target env
+- [ ] Health check endpoint responds
+- [ ] Rollback plan documented
+- [ ] Monitoring/alerting configured
+- [ ] Feature flags set correctly
+
+### Content Checklists
+
+**content (blog/docs):**
+- [ ] Title present and descriptive
+- [ ] No broken links (internal or external)
+- [ ] Images have alt text
+- [ ] Meta description present (≤160 chars)
+- [ ] No placeholder text ("Lorem ipsum", "TODO", "TBD")
+- [ ] Grammar/spell check passes
+- [ ] Publish date set
+- [ ] Author attribution present
+
+### Marketing Checklists
+
+**marketing-email:**
+- [ ] Subject line present (≤60 chars recommended)
+- [ ] Preview text set
+- [ ] All links working and tracked (UTM parameters)
+- [ ] Unsubscribe link present and functional
+- [ ] Physical address included (CAN-SPAM)
+- [ ] Responsive on mobile (test render)
+- [ ] Plain text fallback exists
+- [ ] Sender name and reply-to configured
+
+**marketing-campaign:**
+- [ ] All creative assets finalized
+- [ ] Tracking pixels/UTM parameters configured
+- [ ] Target audience defined and segmented
+- [ ] Budget allocated and approved
+- [ ] Landing page live and tested
+- [ ] A/B test variants set (if applicable)
+- [ ] Schedule confirmed
+
+### Sales Checklists
+
+**sales (deck/proposal):**
+- [ ] Company/prospect name correct throughout
+- [ ] Pricing is current and approved
+- [ ] Contact information accurate
+- [ ] Branding consistent (logos, colors, fonts)
+- [ ] No competitor names misspelled
+- [ ] CTA is clear and actionable
+- [ ] Attached case studies/testimonials current
+- [ ] File format appropriate (PDF for external, editable for internal)
+
+### Research Checklists
+
+**research (paper/report):**
+- [ ] Abstract/executive summary present
+- [ ] All citations properly formatted
+- [ ] Data sources linked and accessible
+- [ ] Methodology section complete
+- [ ] Figures/charts labeled and referenced
+- [ ] Conclusion addresses stated hypothesis
+- [ ] Acknowledgments included
+- [ ] No placeholder references ("[citation needed]")
+
+### Design Checklists
+
+**design (assets/mockups):**
+- [ ] All requested formats exported (PNG, SVG, PDF)
+- [ ] Responsive variants provided (mobile, tablet, desktop)
+- [ ] Color contrast meets WCAG AA (4.5:1 for text)
+- [ ] No placeholder images or text
+- [ ] Source files organized and named
+- [ ] Brand guidelines followed
+- [ ] Handoff notes/specs documented
+
+**Output:** `✓ Phase 3: Checklist generated — [N] items, [P] passing, [F] failing`
+
+## Phase 4: Prepare — Iterative Improvement Loop
+
+Apply the autoresearch loop to fix failing checklist items.
+
+```
+metric = count_passing_checklist_items / total_checklist_items * 100
+direction = higher_is_better
+target = 100 (all items pass)
+
+LOOP (until all pass OR max iterations):
+  1. Read checklist status
+  2. Pick highest-priority failing item
+  3. Fix it (one atomic change)
+  4. Re-run checklist verification
+  5. IF item now passes → keep, log "fixed: [item]"
+  6. IF item still fails → revert, try different approach
+  7. IF all items pass → EXIT LOOP with "ready to ship"
+```
+
+**Priority order for fixes:**
+1. **Blockers** — security issues, broken builds, missing critical content
+2. **Required** — tests, lint, links, compliance items
+3. **Recommended** — descriptions, documentation, polish
+
+**Auto-fix capabilities:**
+- Run test suites and fix failures
+- Fix lint errors automatically
+- Add missing meta descriptions
+- Generate changelog entries from git log
+- Check and fix broken links
+- Add alt text to images (describe or prompt user)
+- Format citations
+- Export missing design formats
+
+**Items that require human input:**
+- Pricing approval
+- Legal review sign-off
+- Brand approval
+- Strategic decisions (A/B test variants)
+- → Flag these and ask user, don't block on them
+
+**Output:** `✓ Phase 4: Preparation complete — [N/N] checklist items passing`
+
+## Phase 5: Dry-Run — Simulate Before Shipping
+
+Execute a simulation of the ship action without side effects.
+
+| Type | Dry-Run Action |
+|------|---------------|
+| code-pr | `gh pr create --draft` or preview PR diff |
+| code-release | Create tag locally (don't push), preview changelog |
+| deployment | Build Docker image, run health checks locally |
+| content | Preview render, check all links resolve |
+| marketing-email | Send test email to sender's own address |
+| marketing-campaign | Preview in ad platform, estimate reach |
+| sales | Preview PDF render, check all pages |
+| research | Export to final format, check pagination |
+| design | Preview all exported formats, check dimensions |
+
+**Dry-run gate:**
+- Present dry-run results to user
+- `--auto` flag: auto-approve if no errors
+- Default: ask user "Ready to ship?" before proceeding
+- `--dry-run` flag: stop here, don't actually ship
+
+**Output:** `✓ Phase 5: Dry-run complete — [result summary]`
+
+## Phase 6: Ship — Execute the Delivery
+
+The actual ship action. Domain-specific.
+
+| Type | Ship Action |
+|------|------------|
+| code-pr | `gh pr create` with full description, request reviewers |
+| code-release | `git tag`, `git push --tags`, create GitHub release |
+| deployment | `git push` to deploy branch, trigger CI/CD, or `kubectl apply` |
+| content | Publish via CMS API, or commit to content branch |
+| marketing-email | Send via ESP API (SendGrid, Mailchimp, etc.) |
+| marketing-campaign | Activate campaign in ad platform |
+| sales | Send email with attachment, or share link |
+| research | Upload to repository, submit to journal/platform |
+| design | Upload to asset library, share with stakeholders |
+
+**Safety rails:**
+- Confirm target (staging vs production, draft vs publish)
+- Log the exact command/action taken
+- Record timestamp
+- Capture any response/confirmation IDs
+
+**Output:** `✓ Phase 6: Shipped — [action taken] at [timestamp]`
+
+## Phase 7: Verify — Post-Ship Health Check
+
+Confirm the shipment actually landed and is healthy.
+
+| Type | Verification |
+|------|-------------|
+| code-pr | PR created, CI running, link accessible |
+| code-release | Tag visible, release page published, assets attached |
+| deployment | Health endpoint returns 200, no error spike in logs |
+| content | Page loads, links work, appears in sitemap |
+| marketing-email | Delivery rate > 95%, no bounce spike |
+| marketing-campaign | Ads serving, landing page loading, tracking firing |
+| sales | Email delivered, link tracking active |
+| research | Accessible via URL/DOI, properly indexed |
+| design | Assets downloadable, correct dimensions |
+
+**Post-ship monitoring (with `--monitor N` flag):**
+```
+FOR N minutes:
+  Check health metrics every 60 seconds
+  IF anomaly detected → ALERT user immediately
+  Log metrics to ship-log
+```
+
+**Output:** `✓ Phase 7: Verified — [health status summary]`
+
+## Phase 8: Log — Record the Shipment
+
+Create a ship log entry for traceability.
+
+**Log format (append to `ship-log.tsv`):**
+```tsv
+timestamp	type	target	checklist_score	dry_run	shipped	verified	duration	notes
+2026-03-16T14:30:00Z	code-pr	#42	18/18	pass	pass	pass	4m32s	auth feature PR
+```
+
+**Summary output:**
+```
+=== Ship Complete ===
+Type: [shipment type]
+Target: [where it went]
+Checklist: [P/T] items passed
+Duration: [total time]
+Status: SHIPPED ✓
+```
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Run all phases except actual ship (stop at Phase 5) |
+| `--auto` | Auto-approve dry-run gate if no errors found |
+| `--force` | Skip non-critical checklist items (still enforce blockers) |
+| `--rollback` | Undo the last ship action (if reversible) |
+| `--monitor N` | Post-ship monitoring for N minutes |
+| `--type <type>` | Override auto-detection with explicit shipment type |
+| `--checklist-only` | Only generate and evaluate checklist (stop at Phase 3) |
+
+## Composite Metric
+
+For bounded loop mode, the ship readiness metric:
+
+```
+ship_score = (checklist_passing / checklist_total) * 80
+           + (dry_run_passed ? 15 : 0)
+           + (no_blockers ? 5 : 0)
+```
+
+- **100** = fully ready to ship
+- **80-99** = ready with minor items (can ship with `--force`)
+- **<80** = not ready, continue preparing
+
+## Rollback Protocol
+
+If `--rollback` is specified or post-ship verification fails:
+
+| Type | Rollback Action |
+|------|----------------|
+| code-pr | Close PR: `gh pr close` |
+| code-release | Delete tag: `git tag -d` + `git push --delete origin` |
+| deployment | Revert deploy: `git revert` or `kubectl rollback` |
+| content | Unpublish/revert to draft |
+| marketing-email | Cannot rollback (flag as "sent") |
+| marketing-campaign | Pause campaign in ad platform |
+| sales | Send correction/follow-up |
+| research | Request retraction or update |
+| design | Revert to previous version in asset library |
+
+**Non-reversible actions** (email, some publications) are flagged before Phase 6 ship action.
+
+## Output Directory
+
+Creates `ship/{YYMMDD}-{HHMM}-{ship-slug}/` with:
+- `checklist.md` — full checklist with pass/fail status
+- `ship-log.tsv` — iteration log (if preparation loop ran)
+- `summary.md` — final ship report


### PR DESCRIPTION
## Summary

- Fixes `/autoresearch:ship`, `/autoresearch:plan`, `/autoresearch:security` returning "Unknown skill"
- Syncs distributable `skills/` directory with ship workflow added in PR #10
- Adds `commands/autoresearch/` directory with command registration files
- Updates README install instructions to include `commands/` directory
- Bumps version `1.1.0` → `1.1.1`

## Root Cause

PR #10 added the ship workflow to `.claude/skills/` (local) but:
1. Never created **command registration files** — Claude Code resolves `parent:subcommand` syntax via `.claude/commands/<parent>/<subcommand>.md`
2. Never synced the distributable `skills/` directory — users cloning the repo got v1.0.4 without the ship workflow

## Files Changed

| File | Change |
|------|--------|
| `commands/autoresearch/ship.md` | New — registers `/autoresearch:ship` |
| `commands/autoresearch/plan.md` | New — registers `/autoresearch:plan` |
| `commands/autoresearch/security.md` | New — registers `/autoresearch:security` |
| `skills/autoresearch/SKILL.md` | Synced from `.claude/` copy + version bump |
| `skills/autoresearch/references/ship-workflow.md` | Synced — was missing from distributable |
| `.claude/skills/autoresearch/SKILL.md` | Version bump 1.1.0 → 1.1.1 |
| `README.md` | Updated install instructions + version badge |

## Test plan

- [ ] Clone fresh, copy both `skills/` and `commands/` directories
- [ ] Run `/autoresearch:ship` — should load ship workflow
- [ ] Run `/autoresearch:plan` — should load plan wizard
- [ ] Run `/autoresearch:security` — should load security audit
- [ ] Verify README install instructions are correct