### PR TITLE
feat: add Claude Code plugin manifest for /plugin install (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "autoresearch",
+  "version": "1.2.0",
+  "description": "Claude Autoresearch — autonomous goal-directed iteration for Claude Code. Inspired by Karpathy's autoresearch: constraint + mechanical metric + autonomous iteration = compounding gains.",
+  "owner": {
+    "name": "Udit Goenka",
+    "url": "https://github.com/uditgoenka"
+  },
+  "plugins": [
+    {
+      "name": "autoresearch",
+      "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:security (STRIDE + OWASP audit), and /autoresearch:ship (multi-phase delivery workflow).",
+      "version": "1.2.0",
+      "author": {
+        "name": "Udit Goenka",
+        "url": "https://github.com/uditgoenka"
+      },
+      "source": ".",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "autoresearch",
+  "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. Includes planning wizard, security audit, and shipping workflow.",
+  "version": "1.2.0",
+  "author": {
+    "name": "Udit Goenka",
+    "url": "https://github.com/uditgoenka"
+  }
+}

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.1.1
+version: 1.2.0
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.1.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 
@@ -99,6 +99,26 @@ Before looping, Claude performs a one-time setup:
 ## Quick Start
 
 ### 1. Install
+
+**Option A — Plugin install (recommended):**
+
+```bash
+/plugin install autoresearch@autoresearch
+```
+
+Or add to your `settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "autoresearch": {
+      "source": { "source": "git", "url": "https://github.com/uditgoenka/autoresearch.git" }
+    }
+  }
+}
+```
+
+**Option B — Manual copy:**
 
 ```bash
 git clone https://github.com/uditgoenka/autoresearch.git
@@ -247,6 +267,9 @@ autoresearch/
 ├── README.md
 ├── EXAMPLES.md                                    ← Real-world examples by domain
 ├── LICENSE
+├── .claude-plugin/
+│   ├── marketplace.json                           ← Plugin marketplace manifest
+│   └── plugin.json                                ← Plugin metadata
 ├── commands/
 │   └── autoresearch/
 │       ├── ship.md                                ← /autoresearch:ship registration

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.1.1
+version: 1.2.0
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` for Claude Code plugin system support
- Users can now install via `/plugin install` instead of manual `cp -r`
- Updates README Quick Start with plugin install as the recommended method
- Bumps version `1.1.1` → `1.2.0`

## Inspired by

PR #13 by @emmahyde — incorporated with fixes:
- Version aligned to `1.2.0` (PR had `1.0.0`)
- Used `url` instead of `email` for author field (privacy)
- README updated with plugin install instructions
- Repo structure section updated

## Install (after merge)

```bash
/plugin install autoresearch@autoresearch
```

## Files Changed

| File | Change |
|------|--------|
| `.claude-plugin/marketplace.json` | New — marketplace manifest |
| `.claude-plugin/plugin.json` | New — plugin metadata |
| `README.md` | Added plugin install to Quick Start, updated version badge + repo structure |
| `skills/autoresearch/SKILL.md` | Version bump 1.1.1 → 1.2.0 |
| `.claude/skills/autoresearch/SKILL.md` | Version bump 1.1.1 → 1.2.0 |

## Test plan

- [ ] Verify `/plugin install autoresearch@autoresearch` works after merge
- [ ] Verify manual install still works
- [ ] Confirm subcommands (`:ship`, `:plan`, `:security`) work via plugin install