### PR TITLE
feat: add /autoresearch:debug and /autoresearch:fix — autonomous debugging & fixing (v1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Claude Autoresearch — autonomous goal-directed iteration for Claude Code. Inspired by Karpathy's autoresearch: constraint + mechanical metric + autonomous iteration = compounding gains.",
   "owner": {
     "name": "Udit Goenka",
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "autoresearch",
-      "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:security (STRIDE + OWASP audit), and /autoresearch:ship (multi-phase delivery workflow).",
-      "version": "1.2.0",
+      "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:security (STRIDE + OWASP audit), /autoresearch:ship (multi-phase delivery workflow), /autoresearch:debug (autonomous bug hunter), and /autoresearch:fix (autonomous error crusher).",
+      "version": "1.3.0",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
-  "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. Includes planning wizard, security audit, and shipping workflow.",
-  "version": "1.2.0",
+  "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. Includes planning wizard, security audit, shipping workflow, autonomous debugger, and autonomous fixer.",
+  "version": "1.3.0",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"

--- a/.claude/commands/autoresearch/debug.md
+++ b/.claude/commands/autoresearch/debug.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:debug
+description: Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
+argument-hint: "[--fix] [--scope <glob>] [--symptom <text>] [--severity <level>]"
+---
+
+Load and follow the autoresearch debug workflow protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the debug workflow reference: `.claude/skills/autoresearch/references/debug-workflow.md` — this is the FULL protocol to follow
+3. Parse any flags from the user's arguments: $ARGUMENTS
+4. Execute the 7-phase debug loop as defined in `debug-workflow.md`
+
+Follow the debug workflow protocol exactly. Every finding requires code evidence (file:line + reproduction steps). Every disproven hypothesis is logged — equally valuable.

--- a/.claude/commands/autoresearch/fix.md
+++ b/.claude/commands/autoresearch/fix.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:fix
+description: Autonomous fix loop — iteratively repairs errors until zero remain. One fix per iteration, atomic, auto-reverted on failure.
+argument-hint: "[--target <cmd>] [--guard <cmd>] [--scope <glob>] [--category <type>] [--from-debug]"
+---
+
+Load and follow the autoresearch fix workflow protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the fix workflow reference: `.claude/skills/autoresearch/references/fix-workflow.md` — this is the FULL protocol to follow
+3. Parse any flags from the user's arguments: $ARGUMENTS
+4. Execute the 8-phase fix loop as defined in `fix-workflow.md`
+
+Follow the fix workflow protocol exactly. ONE fix per iteration. Never suppress errors. Fix implementation, not tests. Auto-revert on regression.

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.2.0
+version: 1.3.0
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
@@ -18,6 +18,8 @@ Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch).
 | `/autoresearch:plan` | Interactive wizard to build Scope, Metric, Direction & Verify from a Goal |
 | `/autoresearch:security` | Autonomous security audit: STRIDE threat model + OWASP Top 10 + red-team (4 adversarial personas) |
 | `/autoresearch:ship` | Universal shipping workflow: ship code, content, marketing, sales, research, or anything |
+| `/autoresearch:debug` | Autonomous bug-hunting loop: scientific method + iterative investigation until codebase is clean |
+| `/autoresearch:fix` | Autonomous fix loop: iteratively repair errors (tests, types, lint, build) until zero remain |
 
 ### /autoresearch:security — Autonomous Security Audit (v1.0.3)
 
@@ -211,6 +213,10 @@ After the wizard completes, the user gets a ready-to-paste `/autoresearch` invoc
 - User says "security audit", "threat model", "OWASP", "STRIDE", "find vulnerabilities", "red-team" → run the security audit
 - User invokes `/autoresearch:ship` → run the ship workflow
 - User says "ship it", "deploy this", "publish this", "launch this", "get this out the door" → run the ship workflow
+- User invokes `/autoresearch:debug` → run the debug loop
+- User says "find all bugs", "hunt bugs", "debug this", "why is this failing", "investigate" → run the debug loop
+- User invokes `/autoresearch:fix` → run the fix loop
+- User says "fix all errors", "make tests pass", "fix the build", "clean up errors" → run the fix loop
 - User says "work autonomously", "iterate until done", "keep improving", "run overnight" → run the loop
 - Any task requiring repeated iteration cycles with measurable outcomes → run the loop
 
@@ -321,5 +327,7 @@ See `references/core-principles.md` for the 7 generalizable principles from auto
 | Refactoring | Tests pass + LOC reduced | Target module | `npm test && wc -l` | `npm run typecheck` |
 | Security | OWASP + STRIDE coverage + findings | API/auth/middleware | `/autoresearch:security` | — |
 | Shipping | Checklist pass rate (%) | Any artifact | `/autoresearch:ship` | Domain-specific |
+| Debugging | Bugs found + coverage | Target files | `/autoresearch:debug` | — |
+| Fixing | Error count (lower) | Target files | `/autoresearch:fix` | `npm test` |
 
 Adapt the loop to your domain. The PRINCIPLES are universal; the METRICS are domain-specific.

--- a/.claude/skills/autoresearch/references/debug-workflow.md
+++ b/.claude/skills/autoresearch/references/debug-workflow.md
@@ -1,0 +1,442 @@
+# Debug Workflow — /autoresearch:debug
+
+Autonomous bug-hunting loop that applies the scientific method iteratively. Doesn't stop at one bug — keeps investigating until the codebase is clean or you interrupt.
+
+**Core idea:** Hypothesize → Test → Prove/Disprove → Log → Repeat. Every finding needs code evidence. Every failed hypothesis teaches the next one.
+
+## Trigger
+
+- User invokes `/autoresearch:debug`
+- User says "find all bugs", "debug this", "why is this failing", "hunt bugs", "investigate"
+- User reports a specific error and wants root cause analysis
+
+## Loop Support
+
+```
+# Unlimited — keep hunting bugs until interrupted
+/autoresearch:debug
+
+# Bounded — exactly N investigation iterations
+/loop 20 /autoresearch:debug
+
+# Focused scope
+/autoresearch:debug
+Scope: src/api/**/*.ts
+Symptom: API returns 500 on POST /users
+```
+
+## Architecture
+
+```
+/autoresearch:debug
+  ├── Phase 1: Gather (symptoms + context)
+  ├── Phase 2: Reconnaissance (scan codebase, map error surface)
+  ├── Phase 3: Hypothesize (form falsifiable hypothesis)
+  ├── Phase 4: Test (run experiment to prove/disprove)
+  ├── Phase 5: Classify (bug found / hypothesis disproven / inconclusive)
+  ├── Phase 6: Log (record finding or elimination)
+  └── Phase 7: Repeat (next hypothesis, next vector)
+```
+
+## Phase 1: Gather — Symptoms & Context
+
+Collect everything known about the problem before investigating.
+
+**If user provides symptoms:**
+- Expected behavior vs actual behavior
+- Error messages, stack traces, log output
+- When it started (commit, deploy, config change)
+- Reproduction steps (if known)
+- Environment (OS, runtime, versions)
+
+**If no symptoms (autonomous bug hunting):**
+- Run existing test suite, collect failures
+- Run linter, collect errors
+- Run type checker, collect issues
+- Check build, collect warnings
+- Scan for common anti-patterns (unhandled promises, unchecked nulls, race conditions)
+
+**Output:** `✓ Phase 1: Gathered — [N] symptoms, [M] error signals detected`
+
+## Phase 2: Reconnaissance — Map the Error Surface
+
+Understand the codebase area where bugs likely live.
+
+**Actions:**
+1. Read files mentioned in stack traces / error messages
+2. Trace call chains from error origin backward
+3. Identify entry points (API routes, event handlers, CLI commands)
+4. Map data flow through affected components
+5. Check recent git changes in affected area (`git log --oneline -20 -- <path>`)
+6. Identify external dependencies and integration points
+
+**Error surface map:**
+```
+Entry Point → Data Flow → Failure Point → Side Effects
+  POST /users → validate() → db.insert() → ← FAILS HERE
+                                             → notification.send() ← cascading
+```
+
+**Output:** `✓ Phase 2: Recon — [N] files scanned, [M] potential failure points mapped`
+
+## Phase 3: Hypothesize — Form Falsifiable Hypothesis
+
+**A good hypothesis is:**
+- Specific: "The JWT validation skips algorithm check on line 42 of auth.ts"
+- Testable: Can be proven/disproven with a concrete experiment
+- Falsifiable: There exists evidence that would prove it wrong
+- Prioritized: Most likely cause first (based on evidence so far)
+
+**Hypothesis formation strategy:**
+
+| Priority | Strategy | When to Use |
+|----------|----------|-------------|
+| 1 | **Error message literal** | Stack trace points to exact line |
+| 2 | **Recent change** | Bug started after specific commit |
+| 3 | **Data flow trace** | Input → Transform → Output chain |
+| 4 | **Environment diff** | Works locally, fails in CI/prod |
+| 5 | **Dependency issue** | After upgrade/install |
+| 6 | **Race condition** | Intermittent, timing-dependent |
+| 7 | **Edge case** | Works for most inputs, fails for specific ones |
+
+**Cognitive bias guards:**
+- Confirmation bias: Actively seek evidence AGAINST your hypothesis
+- Anchoring: Don't fixate on the first clue — consider alternatives
+- Sunk cost: If 3 experiments fail to confirm, abandon and try new hypothesis
+- Availability: Just because a bug pattern is familiar doesn't mean it's the cause
+
+**Output:** `Hypothesis [N]: "[specific, testable claim]" — testing...`
+
+## Phase 4: Test — Run Experiment
+
+Design a minimal experiment that definitively proves or disproves the hypothesis.
+
+**Experiment types:**
+
+| Type | Method | Best For |
+|------|--------|----------|
+| **Direct inspection** | Read the code at suspected location | Logic errors, missing checks |
+| **Trace execution** | Add logging, run, read output | Data flow issues |
+| **Minimal reproduction** | Create smallest failing case | Complex interactions |
+| **Binary search** | Comment out half the code, narrow | "Something in this file breaks" |
+| **Differential** | Compare working vs broken (git diff, env diff) | Regressions |
+| **Git bisect** | Find exact commit that introduced bug | "It used to work" |
+| **Input variation** | Change inputs systematically | Edge cases, boundary issues |
+
+**Experiment rules:**
+- ONE experiment per iteration (atomic — know exactly what you tested)
+- Record the exact command/action and its output
+- If experiment is destructive, git stash first
+- Timeout: if an experiment takes >30 seconds, it's too complex — simplify
+
+## Phase 5: Classify — What Did We Learn?
+
+| Result | Action |
+|--------|--------|
+| **Bug confirmed** | Record finding with full evidence, severity, location |
+| **Hypothesis disproven** | Log as eliminated, extract learnings for next hypothesis |
+| **Inconclusive** | Refine hypothesis with additional constraints, re-test |
+| **New lead discovered** | Log discovery, add to hypothesis queue |
+
+**Bug finding format:**
+```
+### [SEVERITY] Bug: [title]
+- **Location:** `file:line`
+- **Hypothesis:** [what we suspected]
+- **Evidence:** [code snippet + experiment result]
+- **Reproduction:** [exact steps to trigger]
+- **Impact:** [what breaks, who's affected]
+- **Root cause:** [WHY it happens, not just WHAT happens]
+- **Suggested fix:** [concrete code change]
+```
+
+**Severity classification:**
+| Level | Criteria |
+|-------|----------|
+| CRITICAL | Data loss, security breach, system crash |
+| HIGH | Feature broken, incorrect results, performance degradation >10x |
+| MEDIUM | Edge case failure, degraded UX, workaround exists |
+| LOW | Cosmetic, minor inconsistency, theoretical risk |
+
+## Phase 6: Log — Record Everything
+
+**Append to debug-results.tsv:**
+```tsv
+iteration	type	hypothesis	result	severity	location	description
+1	hypothesis	JWT skips alg check	confirmed	CRITICAL	auth.ts:42	Algorithm confusion vulnerability
+2	hypothesis	Rate limit missing	disproven	-	-	Rate limiter exists in middleware
+3	discovery	-	new_lead	-	db.ts:88	Unhandled promise rejection in insert
+4	hypothesis	DB insert missing await	confirmed	HIGH	db.ts:88	Silent failure on write errors
+```
+
+**Every 5 iterations, print progress:**
+```
+=== Debug Progress (iteration 10) ===
+Bugs found: 3 (1 Critical, 1 High, 1 Medium)
+Hypotheses tested: 8 (3 confirmed, 4 disproven, 1 inconclusive)
+Files investigated: 14 / 47 in scope
+Techniques used: direct inspection, trace, binary search
+```
+
+## Phase 7: Repeat — Next Investigation
+
+**Prioritization for next iteration:**
+1. Follow new leads discovered during previous experiments
+2. Untested high-priority hypotheses
+3. Uninvestigated files in the error surface
+4. Deeper investigation of confirmed bugs (find root cause, not just symptom)
+5. Pattern-based search (if found NULL check bug, look for similar patterns elsewhere)
+
+**When to stop (unbounded mode):**
+- Never stop automatically — user interrupts
+- Print a "diminishing returns" warning after 5 iterations with no new findings
+
+**When to stop (bounded mode):**
+- After N iterations, print final summary and stop
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--fix` | After finding bugs, switch to autoresearch:fix mode to fix them |
+| `--scope <glob>` | Limit investigation to specific files |
+| `--symptom "<text>"` | Pre-fill symptom instead of asking |
+| `--severity <level>` | Only report findings at or above this severity |
+| `--technique <name>` | Force a specific investigation technique |
+
+## Composite Metric
+
+For bounded loops, the debug thoroughness metric:
+
+```
+debug_score = bugs_found * 15
+            + hypotheses_tested * 3
+            + (files_investigated / files_in_scope) * 40
+            + (techniques_used / 7) * 10
+```
+
+Higher = more thorough. Incentivizes breadth (cover more files) AND depth (test more hypotheses).
+
+## Investigation Techniques Reference
+
+### Binary Search
+Comment out half the suspicious code. If bug disappears, it's in that half. Repeat.
+
+### Differential Debugging
+Compare working state vs broken state:
+- `git stash` to test clean state
+- `git bisect` to find exact breaking commit
+- Environment variables diff between working/failing environments
+
+### Minimal Reproduction
+Strip away everything until you have the smallest possible case that reproduces the bug. Fewer moving parts = clearer cause.
+
+### Trace Execution
+Add strategic console.log/print statements at key data flow points. Run and read the actual values vs expected values.
+
+### Pattern Search
+Found one bug? Search for the same anti-pattern across the codebase:
+```bash
+grep -rn "pattern" src/ --include="*.ts"
+```
+
+### Working Backwards
+Start from the error (output) and trace backward through the code until you find where correct behavior diverges from actual behavior.
+
+### Rubber Duck
+Explain the code out loud, line by line. The act of explaining often reveals the assumption that's wrong.
+
+## Common Bug Patterns by Language
+
+Quick reference for language-specific bugs to scan for during reconnaissance.
+
+| Language | Classic Bug | Pattern to Search | Why It Happens |
+|----------|-------------|-------------------|----------------|
+| **JavaScript** | Unhandled promise rejection | `Promise` without `.catch` / missing `await` | Async errors are swallowed silently |
+| **TypeScript** | `undefined` access after null check narrowing | `obj?.prop` then `obj.other` (lost narrowing) | Type narrowing is scope-limited |
+| **Python** | Mutable default argument | `def f(x=[]):` — shared across all calls | Python evaluates defaults once at definition time |
+| **Python** | `None` injection from unchecked return | Function returns `None` on error path, caller chains it | Missing null/None guard |
+| **Go** | Goroutine leak | Goroutine blocks on channel that's never closed | Missing `defer close(ch)` or `context.Cancel()` |
+| **Go** | Race condition on shared map | Concurrent read/write without mutex | Maps in Go are not goroutine-safe |
+| **Go** | Integer overflow in slice/buffer ops | `int` size differences on 32-bit vs 64-bit | Implicit numeric type assumptions |
+| **Rust** | Panic in production from `.unwrap()` | `Option::unwrap()` / `Result::unwrap()` on `Err` | Error path not handled |
+| **Java** | `NullPointerException` cascade | Unguarded method chain `a.b().c().d()` | No null checks in chain |
+| **Java** | SQL injection via string concat | `"SELECT * FROM t WHERE id=" + id` | Missing parameterized queries |
+| **SQL** | N+1 query | Loop calling DB inside loop | Missing JOIN or batch fetch |
+| **All** | Race condition on shared state | Global/singleton mutated from concurrent threads | Missing synchronization |
+| **All** | Integer overflow in calculations | Arithmetic on large numbers without bounds check | Silent wrap-around on overflow |
+| **All** | Injection vulnerability | User input concatenated into command/query/template | Missing sanitization/escaping |
+
+**Reconnaissance shortcut:** When entering Phase 2, grep for these patterns first — they're statistically the most common issues.
+
+## Domain-Specific Debugging
+
+Different domains have predictable failure modes. Apply domain-specific reconnaissance before forming hypotheses.
+
+### API Bugs
+
+Common failure points: auth middleware order, content-type mismatch, serialization/deserialization, HTTP status code semantics.
+
+**API debug checklist:**
+- Does the route exist and match the HTTP method?
+- Is auth middleware applied and in the correct order?
+- Does the request body parse correctly (Content-Type header)?
+- Are 4xx responses distinguishable from 5xx? Is error shape consistent?
+- Are query parameters validated and typed correctly?
+
+### Database Bugs
+
+Common failure points: N+1 queries, missing transactions, constraint violations swallowed by ORM, timezone handling, NULL propagation.
+
+**Database debug checklist:**
+- Are all writes wrapped in transactions where atomicity is needed?
+- Are NULL values handled at the DB and application layer?
+- Is the query hitting an index? (check with `EXPLAIN`)
+- Is connection pooling exhausted? (check connection count vs pool limit)
+- Are timestamps stored as UTC? Converted correctly on read?
+
+### Authentication / Authorization Bugs
+
+Common failure points: token validation skipping algorithm check, expired token not rejected, privilege escalation from missing ownership check.
+
+**Auth debug checklist:**
+- Is the JWT `alg` field validated (prevent algorithm confusion attacks)?
+- Is token expiry (`exp`) checked?
+- Is authorization (ownership check) separate from authentication (identity check)?
+- Are there privilege escalation paths (e.g., regular user accessing admin endpoint)?
+
+### Async / Concurrency Bugs
+
+Common failure points: race conditions on shared state, missing await causing partial execution, event loop blocking, deadlock.
+
+**Async debug checklist:**
+- Is every `async` function `await`ed at the call site?
+- Are shared mutable state accesses synchronized (mutex, lock, atomic)?
+- Is there a risk of deadlock (two locks acquired in different orders)?
+- Are network/database calls inside async handlers non-blocking?
+
+### Network / Integration Bugs
+
+Common failure points: timeout misconfiguration, retry storm on transient failure, missing circuit breaker, charset encoding mismatch.
+
+**Network debug checklist:**
+- Are timeouts set on all outbound calls?
+- Is retry logic bounded (exponential backoff with max retries)?
+- Is response parsing resilient to unexpected fields?
+- Are character encoding assumptions explicit (UTF-8 everywhere)?
+
+## What NOT to Do — Debug Anti-Patterns
+
+| Anti-Pattern | Why It Fails |
+|---|---|
+| **Fix before understanding** | You'll fix symptoms, not causes. The bug comes back. |
+| **Change multiple things at once** | Can't attribute improvement/regression to any single change. |
+| **Ignore disproven hypotheses** | Not logging eliminations means repeating failed investigations. |
+| **Assume instead of verify** | "It's probably X" without testing = confirmation bias. Run the experiment. |
+| **Skip reproduction** | If you can't reproduce it, you can't verify the fix. |
+| **Debug in production** | Never investigate with live data. Reproduce locally first. |
+| **Tunnel vision on one file** | Bugs often span boundaries. Trace the full data flow. |
+| **Trust error messages literally** | Error messages describe symptoms. Root cause is often 2-3 layers deeper. |
+| **Give up after 3 tries** | Some bugs need 10+ hypotheses. Shift technique, don't stop. |
+| **Blame the framework** | 95% of the time it's your code. Prove framework bug with minimal reproduction first. |
+
+## Multi-File Bug Tracing
+
+When a bug spans multiple files or services, standard single-file inspection fails. Use a structured cross-file trace.
+
+**When to apply:**
+- Stack trace crosses multiple files/modules
+- Bug involves data transformation across service boundaries
+- Fix in one file doesn't resolve the issue (symptom vs cause)
+
+**Protocol:**
+1. Start at the symptom (error output or failing assertion)
+2. Trace backwards across file boundaries: identify the data/call flowing in
+3. For each file in the trace, record: what goes in, what comes out, where it transforms
+4. Identify the first file where the output diverges from the expected contract
+5. That file owns the bug — even if it's not where the error surfaces
+
+**Multi-file trace map format:**
+```
+file-a.ts → file-b.ts → file-c.ts → ERROR
+  input: {...}  transform: {...}  output: WRONG
+         ^first divergence = root cause lives here
+```
+
+**Across microservices:** Add network boundaries to the map. Include request/response payloads at each service boundary. A bug "in service B" often means service A sent malformed data.
+
+## Performance Bug Investigation
+
+Performance bugs are correctness bugs where the output is "too slow" rather than "wrong". Apply the same scientific method with profiling as the measurement tool.
+
+**Profiling first, guessing second:**
+- Profile before optimizing — the slow part is almost never where you think
+- Identify the single hottest path (slow query, slow render, slow computation)
+- Reproduce the slowness with a minimal benchmark before attempting a fix
+
+**Performance issue patterns:**
+| Symptom | Likely Cause | Investigation Method |
+|---------|--------------|---------------------|
+| Slow API response | N+1 database queries | Log SQL queries, count DB calls per request |
+| Slow page render | Expensive recomputation on every render | Profiling (React DevTools, Chrome DevTools) |
+| Slow background job | Missing index on query inside loop | `EXPLAIN ANALYZE` on repeated queries |
+| Gradual memory growth | Memory leak (event listeners, unclosed connections) | Heap snapshots over time |
+| Slow cold start | Over-importing, large bundle, slow init code | Bundle analyzer, startup profiling |
+| Intermittent slow requests | Lock contention or connection pool exhaustion | DB slow query log, connection pool metrics |
+
+**Performance debug checklist:**
+1. Measure baseline (p50, p95, p99 latency or total time)
+2. Profile to find the actual hotspot (not the assumed one)
+3. Form hypothesis: "removing X will reduce Y by Z%"
+4. Implement ONE change, re-measure
+5. Verify improvement is statistically significant (not noise)
+
+## The 5 Whys — Root Cause Drill-Down
+
+Surface errors rarely reveal root causes. Ask "why" recursively until you reach a fundamental cause you can permanently fix.
+
+**Template:**
+```
+Symptom: [what the user/system reported]
+Why 1: [immediate technical cause]
+Why 2: [cause of the cause]
+Why 3: [deeper system issue]
+Why 4: [process or design flaw]
+Why 5: [root cause — fixable permanently]
+```
+
+**Example:**
+```
+Symptom: API returns 500 on POST /users
+Why 1: database insert throws ConstraintViolationError
+Why 2: email field is empty string, violates NOT NULL constraint
+Why 3: validation layer allows empty strings as valid email
+Why 4: validation uses truthy check (empty string is falsy — wait, it isn't)
+Why 5: regex validator has a bug — accepts empty string as valid email format
+Root Fix: fix the email regex to require at least one character before @
+```
+
+**Stop when:** The why leads to an external system outside your control, a deliberate design decision, or a hardware/infrastructure limit. Those get a workaround, not a root fix.
+
+**Stop asking why if:** You reach a fix that prevents ALL future instances of this class of bug — not just this specific instance.
+
+## Output Directory
+
+Creates `debug/{YYMMDD}-{HHMM}-{debug-slug}/` with:
+- `findings.md` — all confirmed bugs with evidence
+- `eliminated.md` — disproven hypotheses (equally valuable)
+- `debug-results.tsv` — iteration log
+- `summary.md` — executive summary with recommendations
+
+## Chaining with /autoresearch:fix
+
+```
+# Find bugs, then fix them
+/autoresearch:debug --fix
+
+# Or manually chain
+/loop 15 /autoresearch:debug    # hunt bugs
+/loop 20 /autoresearch:fix      # fix everything found
+```
+
+When `--fix` is specified, after the debug loop completes, automatically switches to `/autoresearch:fix` targeting the discovered issues.

--- a/.claude/skills/autoresearch/references/fix-workflow.md
+++ b/.claude/skills/autoresearch/references/fix-workflow.md
@@ -1,0 +1,650 @@
+# Fix Workflow — /autoresearch:fix
+
+Autonomous fix loop that takes a broken state and iteratively repairs it until everything passes. One fix per iteration. Atomic, committed, verified, auto-reverted on failure.
+
+**Core idea:** Detect → Prioritize → Fix ONE thing → Verify → Keep/Revert → Repeat until zero errors.
+
+## Trigger
+
+- User invokes `/autoresearch:fix`
+- User says "fix all errors", "make tests pass", "fix the build", "clean up all warnings"
+- User has output from `/autoresearch:debug` and wants to fix the findings
+
+## Loop Support
+
+```
+# Unlimited — keep fixing until everything passes
+/autoresearch:fix
+
+# Bounded — exactly N fix iterations
+/loop 30 /autoresearch:fix
+
+# With explicit target
+/autoresearch:fix
+Target: make all tests pass
+Scope: src/**/*.ts
+Guard: npm run typecheck
+```
+
+## Architecture
+
+```
+/autoresearch:fix
+  ├── Phase 1: Detect (what's broken?)
+  ├── Phase 2: Prioritize (fix order)
+  ├── Phase 3: Fix ONE thing (atomic change)
+  ├── Phase 4: Commit (before verification)
+  ├── Phase 5: Verify (did error count decrease?)
+  ├── Phase 6: Guard (did anything else break?)
+  ├── Phase 7: Decide (keep / revert / rework)
+  └── Phase 8: Log & Repeat
+```
+
+## Phase 1: Detect — What's Broken?
+
+Auto-detect the failure domain from context, or accept explicit target.
+
+**Detection algorithm:**
+```
+FUNCTION detectFailures(context):
+  failures = []
+
+  # Run test suite
+  IF test runner detected (jest, pytest, vitest, go test, cargo test):
+    result = run_tests()
+    IF failures → ADD {type: "test", count: N, details: [...]}
+
+  # Run type checker
+  IF typescript detected:
+    result = run("tsc --noEmit")
+    IF errors → ADD {type: "type", count: N, details: [...]}
+
+  # Run linter
+  IF linter detected (eslint, ruff, clippy):
+    result = run_lint()
+    IF errors → ADD {type: "lint", count: N, details: [...]}
+
+  # Run build
+  IF build script detected:
+    result = run_build()
+    IF fails → ADD {type: "build", count: 1, details: [...]}
+
+  # Check for debug findings
+  IF debug/{latest}/findings.md exists:
+    bugs = parse_findings()
+    ADD {type: "bug", count: N, details: [...]}
+
+  # Check CI
+  IF .github/workflows/ exists:
+    IF user mentions CI failure → ADD {type: "ci", count: 1, details: [...]}
+
+  # Detect warnings (lower priority but tracked)
+  IF warning-level output detected:
+    result = run_warnings()
+    IF warnings → ADD {type: "warning", count: N, details: [...]}
+
+  RETURN failures sorted by severity
+```
+
+**Output:** `✓ Phase 1: Detected — [N] test failures, [M] type errors, [K] lint errors, [W] warnings`
+
+**Detection priority note:** Run build first — if build fails, type/test/lint results are unreliable. Warnings are detected last; {type: "warning"} items go to lowest priority queue.
+
+## Phase 2: Prioritize — Fix Order
+
+Fix in this order (blockers first, polish last):
+
+| Priority | Category | Why First |
+|----------|----------|-----------|
+| 1 | **Build failures** | Nothing works if it doesn't compile |
+| 2 | **Critical/High bugs** | From debug findings — data loss, security |
+| 3 | **Type errors** | Type safety prevents cascading bugs |
+| 4 | **Test failures** | Tests verify correctness |
+| 5 | **Medium/Low bugs** | From debug findings |
+| 6 | **Lint errors** | Code quality |
+| 7 | **Warnings** | Polish — type "warning" in detection |
+
+**Within a category, prioritize by:**
+1. Cascading impact (fixing one may fix others downstream)
+2. Simplicity (quick wins first — build momentum)
+3. File locality (fixes in same file grouped)
+
+**Output:** `✓ Phase 2: Prioritized — fixing [category] first ([N] items)`
+
+## Phase 3: Fix ONE Thing — Atomic Change
+
+Pick the highest-priority unfixed item and make ONE focused change.
+
+**Fix strategies by category:**
+
+| Category | Strategy |
+|----------|----------|
+| Build failure | Read error, fix the exact line/import/config |
+| Type error | Add proper types, fix signatures, handle null cases |
+| Test failure | Read test + implementation, find mismatch, fix implementation (not test) |
+| Lint error | Apply the rule — auto-fix where possible |
+| Bug (from debug) | Apply the suggested fix from findings.md |
+| Warning | Resolve the underlying issue, don't suppress |
+
+**Fix Strategies by Language:**
+
+| Language | Never Do | Correct Pattern |
+|----------|----------|-----------------|
+| TypeScript | `any`, `@ts-ignore`, type assertions to bypass | Proper interfaces, generics, discriminated unions |
+| Python | Bare `except:`, missing type hints on public API | `except SpecificError:`, full type hints with `from __future__ import annotations` |
+| Go | Ignoring errors with `_`, `panic` in library code | Explicit error wrapping `fmt.Errorf("context: %w", err)`, propagate with context |
+| Rust | `.unwrap()` in production, silencing `#[allow(unused)]` | `Result<T, E>` propagation with `?`, custom error types with `thiserror` |
+| Java | Swallowing exceptions, raw types | Typed exceptions, generics, checked exception handling |
+
+**Rules:**
+- ONE fix per iteration. Not two. Not "while I'm here."
+- Fix the IMPLEMENTATION, not the test (unless the test is genuinely wrong)
+- Never add `@ts-ignore`, `eslint-disable`, `# type: ignore` to suppress errors
+- Never use any|any escape hatch never solves type errors — use proper narrowed types or generics
+- Never delete test|delete test coverage never improves code — fix the implementation to satisfy tests
+- Prefer minimal changes — smallest diff that fixes the issue
+
+## Phase 4: Commit — Before Verification
+
+```bash
+git add -A
+git commit -m "fix: [what was fixed] — [file:line]"
+```
+
+Commit BEFORE running verification. This enables clean rollback if the fix breaks something.
+
+## Phase 5: Verify — Did It Help?
+
+Re-run the detection from Phase 1 and compare:
+
+```
+previous_errors = error_count_before
+current_errors = error_count_after
+
+delta = previous_errors - current_errors
+```
+
+**Expected:** `delta > 0` (fewer errors than before)
+
+## Phase 6: Guard — Did Anything Else Break?
+
+If a guard command is specified, run it:
+
+```
+guard_result = run(guard_command)  # e.g., "npm test"
+```
+
+**Guard prevents regressions.** Fixing a type error shouldn't break a test. Fixing a test shouldn't break the build.
+
+## Phase 7: Decide — Keep, Revert, or Rework
+
+| Condition | Action |
+|-----------|--------|
+| `delta > 0` AND guard passes | **KEEP** — commit stays, log "fixed" |
+| `delta > 0` AND guard fails | **REWORK** — revert, try different approach (max 2 attempts) |
+| `delta == 0` | **DISCARD** — revert, fix didn't help |
+| `delta < 0` (more errors!) | **DISCARD** — revert immediately |
+| Crash during fix | **RECOVER** — revert, try simpler approach (max 3 attempts) |
+
+**Rework strategy (when guard fails):**
+1. Read the guard failure — understand what regressed
+2. Revert the failing fix: `git revert HEAD --no-edit`
+3. Understand why the fix broke something else (check cascading dependencies)
+4. Find an approach that fixes the target WITHOUT breaking the guard
+5. If 2 rework attempts fail → skip this item, add to `blocked.md`, move to next
+6. Log in fix-results.tsv with status "rework" and description of what was attempted
+
+**Decision matrix extended:**
+
+| Condition | delta | Guard | Action | TSV Status |
+|-----------|-------|-------|--------|-----------|
+| Perfect fix | > 0 | pass | KEEP | fixed |
+| Partial fix | > 0 | pass | KEEP + continue | fixed |
+| Regression introduced | > 0 | fail | REWORK | rework |
+| No effect | == 0 | - | DISCARD | discard |
+| Made it worse | < 0 | - | DISCARD immediately | discard |
+| Crash/exception | any | fail | RECOVER (simpler) | recover |
+| 3rd attempt fails | any | any | SKIP to blocked | blocked |
+
+## Phase 8: Log & Repeat
+
+**Append to fix-results.tsv:**
+```tsv
+iteration	category	target	delta	guard	status	description
+0	-	-	-	pass	baseline	47 test failures, 12 type errors, 3 lint errors
+1	type	auth.ts:42	-2	pass	fixed	add return type annotation
+2	type	db.ts:15	-1	pass	fixed	handle nullable column
+3	test	api.test.ts	-3	pass	fixed	fix expected status code (was 200, should be 201)
+4	test	auth.test.ts	0	-	discard	wrong approach — test expectation was correct
+5	test	auth.test.ts	-1	pass	fixed	missing await on async handler
+```
+
+**Every 5 iterations, print progress:**
+```
+=== Fix Progress (iteration 15) ===
+Baseline: 62 errors → Current: 23 errors (-39, -63%)
+Category breakdown:
+  Tests:  31/47 fixed
+  Types:  8/12 fixed
+  Lint:   0/3 fixed (not yet started — lower priority)
+Keeps: 11 | Discards: 3 | Reworks: 1
+```
+
+**Completion detection:**
+```
+IF current_errors == 0:
+  PRINT "=== All Clear — Zero Errors ==="
+  STOP (even in unbounded mode)
+```
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--target <command>` | Explicit verify command (overrides auto-detection) |
+| `--guard <command>` | Safety command that must always pass |
+| `--scope <glob>` | Limit fixes to specific files |
+| `--category <type>` | Only fix specific category (test, type, lint, build, bug) |
+| `--skip-lint` | Don't fix lint errors (focus on functional issues) |
+| `--from-debug` | Read findings from latest debug/ session |
+
+## Fix Session State Machine
+
+```
+States: DETECTING → PRIORITIZING → FIXING → VERIFYING → DECIDING → [DONE | LOOP]
+
+DETECTING:
+  → Run all error detection commands
+  → If zero errors found → DONE (nothing to fix)
+  → If errors found → PRIORITIZING
+
+PRIORITIZING:
+  → Sort errors by priority table
+  → Group cascading errors (fixing one fixes others)
+  → Pick first unfixed item → FIXING
+
+FIXING:
+  → Read error details + surrounding code
+  → Assess blast radius (impact assessment)
+  → Check git history for prior attempts on this file
+  → Apply minimal change
+  → Commit → VERIFYING
+
+VERIFYING:
+  → Re-run error detection
+  → Compute delta (previous - current)
+  → Run guard command → DECIDING
+
+DECIDING:
+  → delta > 0 AND guard passes → KEEP → log "fixed" → LOOP
+  → delta > 0 AND guard fails → REWORK (max 2) → FIXING
+  → delta == 0 → DISCARD → revert → PRIORITIZING (next item)
+  → delta < 0 → DISCARD → revert immediately → PRIORITIZING
+  → 3 failed attempts on same item → SKIP → blocked list → PRIORITIZING
+  → All items fixed or skipped → DONE
+
+DONE:
+  → Generate summary.md
+  → Print fix_score
+  → Suggest /autoresearch:debug for blocked items
+```
+
+## What NOT to Do — Anti-Patterns
+
+These shortcuts seem to fix the error but make things worse:
+
+| Anti-Pattern | Why It's Wrong | Do This Instead |
+|--------------|----------------|-----------------|
+| Add `@ts-ignore` / `eslint-disable` | Hides the problem — resurfaces as runtime error | Fix the root cause |
+| Use `any` type to silence TypeScript | Defeats type safety for the whole chain | Use proper types, generics, or `unknown` with narrowing |
+| Delete or skip failing tests | Removes the safety net | Fix the implementation to satisfy the test |
+| Suppress lint with inline comments | Accumulates tech debt silently | Apply the lint rule correctly |
+| `catch (e) {}` empty catch blocks | Swallows errors — bugs become invisible | Log at minimum; handle or re-throw |
+| Comment out broken code | It will never be uncommented | Fix it or delete it entirely |
+| Hardcode values to pass specific tests | Test passes, but feature is broken for real data | Fix the logic, not the values |
+| `--force` on npm/yarn install | Ignores peer dep conflicts causing runtime crashes | Resolve conflicts explicitly |
+| Increase test timeouts without fixing cause | Masks slow code or deadlocks | Profile and fix the underlying issue |
+
+**The ONE fix rule prevents most anti-patterns.** When tempted to use one, it signals the real fix is harder — log it, skip to next item, return with fresh context.
+
+## Fix Verification Depth
+
+Verification depth scales with blast radius:
+
+| Change Scope | Minimum Verification | Full Verification |
+|-------------|---------------------|-------------------|
+| Single utility function | Unit tests for that function | Unit + integration tests for callers |
+| Public API change | Integration tests | Unit + integration + contract tests |
+| Database schema | Migration dry-run | Staging environment smoke test |
+| Config / env var | CI pipeline run | Full deployment to staging |
+| Dependency upgrade | `npm test` | Full regression suite + e2e |
+| Auth / security code | Unit + integration | Security audit + penetration test |
+
+## Composite Metric
+
+For bounded loops, a nuanced fix_score accounting for quality of fixes:
+
+```
+fix_score = reduction_score + quality_score + bonus_score
+
+reduction_score = ((baseline_errors - current_errors) / baseline_errors) * 60
+  # Weight: 60% — primary goal is reducing errors
+
+quality_score = 0
+  # Deduct for low-quality fixes (anti-patterns used):
+  quality_score -= (suppression_count * 5)   # @ts-ignore, eslint-disable used
+  quality_score -= (skipped_test_count * 10)  # tests deleted/commented out
+  quality_score -= (any_type_count * 3)       # `any` type introduced
+  quality_score = max(quality_score, -20)     # floor: never below -20
+
+guard_score = (guard_always_passed ? 25 : 0)
+  # Weight: 25% — no regressions is critical
+
+bonus_score = 0
+  bonus_score += (zero_errors ? 10 : 0)              # all clear bonus
+  bonus_score += (no_discards ? 5 : 0)               # every fix worked first try
+  bonus_score += (compound_detected_and_fixed ? 5 : 0) # found hidden bugs too
+```
+
+**Interpretation:**
+- **100+** = perfect: all errors fixed, no regressions, no anti-patterns
+- **80-99** = good: significant progress, guards held, minimal anti-patterns
+- **60-79** = acceptable: meaningful reduction, but some regressions or anti-patterns
+- **<60** = needs work: too many discards, guard failures, or anti-patterns used
+
+## Fix Impact Assessment
+
+Before applying a fix, estimate the blast radius:
+
+```
+FUNCTION assessImpact(target_file, fix_type):
+  # How many files import this file?
+  dependents = grep -r "import.*{target_file}" src/
+
+  # Is this in a critical path?
+  is_critical = target_file in [auth, payments, database, api-gateway]
+
+  # How many tests cover this?
+  test_coverage = count tests that import or test target_file
+
+  RETURN {
+    dependents: N,
+    is_critical: bool,
+    test_coverage: N,
+    risk_level: HIGH if (dependents > 10 OR is_critical) else MEDIUM if dependents > 3 else LOW
+  }
+```
+
+| Risk Level | Action |
+|------------|--------|
+| LOW | Fix and verify with unit tests |
+| MEDIUM | Fix with unit + integration tests as guard |
+| HIGH | Fix in isolation branch, verify against full suite, get review before merge |
+
+## Compound Fix Detection
+
+When fixing one error reveals another, or a fix is only partial:
+
+```
+FUNCTION detectCompound(before_errors, after_errors):
+  new_errors = after_errors - before_errors  # errors that didn't exist before
+
+  IF new_errors > 0:
+    LOG "Compound fix detected: {N} new errors surfaced"
+    # These are likely pre-existing errors that were masked
+    ADD new_errors to fix queue at current priority
+    CONTINUE (do not treat as regression)
+
+  IF delta == 0 AND error_details_changed:
+    LOG "Error transformed — not fixed, just moved"
+    REVERT and try different approach
+```
+
+**Common compound patterns:**
+- Fixing a type error reveals a logic error that the wrong type was hiding
+- Fixing a null check reveals a missing initialization
+- Upgrading a dependency reveals previously passing tests were relying on a bug
+- Fixing test A reveals test B was sharing mutable state
+
+## Rollback Protocol
+
+When a fix makes things worse (delta < 0) or breaks the guard:
+
+```
+STEP 1: Identify the bad commit
+  git log --oneline -5
+
+STEP 2: Revert the specific commit
+  git revert HEAD --no-edit
+  # OR for harder cases:
+  git reset --soft HEAD~1  # unstage the commit
+  git checkout -- .        # discard working changes
+
+STEP 3: Verify rollback succeeded
+  Run original failing command — should return to pre-fix error count
+
+STEP 4: Log the failed approach in fix-results.tsv
+  Mark as "discard" with description of why it failed
+
+STEP 5: Analyze before retrying
+  - What assumption was wrong?
+  - What did the fix break?
+  - Is there a smaller, safer change?
+```
+
+**Never skip rollback.** A partial fix in a broken state makes the next iteration's error detection unreliable.
+
+## Parallel Fix Detection
+
+Some errors are independent and can be fixed in parallel (separate files, no shared state):
+
+```
+FUNCTION detectParallelizable(error_list):
+  groups = {}
+
+  FOR each error:
+    affected_files = error.file
+    FOR each group:
+      IF affected_files overlaps group.files:
+        MERGE error into group  # dependent
+      ELSE:
+        CREATE new group        # independent
+
+  independent_groups = groups where len(group.files) == 1
+
+  RETURN independent_groups  # can be fixed in parallel subagents
+```
+
+**When to parallelize:** 5+ independent errors across different modules. Spawn parallel fix agents with `--scope` to isolate.
+
+## Fix History Pattern Learning
+
+Before attempting a fix, check git history for past approaches on the same file:
+
+```bash
+# See what fixes were tried in this file before
+git log --oneline --follow -- src/auth/handler.ts
+
+# See the diff of a specific past fix
+git show <commit-hash> -- src/auth/handler.ts
+
+# Search for past fix attempts on this error type
+git log --grep="fix: type error" --oneline
+```
+
+**Pattern signals:**
+- Same error fixed 3+ times → root cause not addressed, fix the architectural issue
+- Recent revert in same file → previous approach failed, avoid repeating it
+- Large diff for "simple" fix → complexity hidden in that file, be careful with changes
+
+## The Fix Didn't Work — Escalation Path
+
+When 3 attempts at the same error fail:
+
+```
+Attempt 1: FAIL → Log approach, try different strategy
+Attempt 2: FAIL → Log approach, read git history for prior attempts
+Attempt 3: FAIL → Escalate:
+
+  1. DOCUMENT: What was tried (3 approaches), why each failed
+  2. ISOLATE: Create minimal reproduction case
+  3. SKIP: Move this error to "blocked" list, continue with others
+  4. FLAG: Note in summary.md — "Error X requires investigation"
+  5. SUGGEST: /autoresearch:debug on the specific error for root cause analysis
+```
+
+**Never loop on the same failing approach.** Each attempt must use a materially different strategy.
+
+## Dependency Fix Patterns
+
+When the error originates from `node_modules`, `pip` packages, or vendored dependencies:
+
+| Symptom | Strategy | Command |
+|---------|----------|---------|
+| Peer dependency conflict | Upgrade to compatible version | `npm install pkg@latest` |
+| Breaking change in minor update | Pin to last working version | `npm install pkg@1.2.3` |
+| Security vulnerability | Patch or replace | `npm audit fix` / replace with alternative |
+| Transitive dependency conflict | Force resolution | `package.json` resolutions/overrides field |
+| Python package incompatibility | Pin in requirements | `pip install pkg==x.y.z` |
+| Missing native bindings | Rebuild from source | `npm rebuild` / `pip install --no-binary` |
+
+**Rule:** Never vendor-patch `node_modules` directly — it will be overwritten. Add a `patch-package` patch or fork.
+
+## Database Migration Fix Patterns
+
+When errors involve schema conflicts or data integrity:
+
+| Error Type | Strategy |
+|------------|----------|
+| Migration out of order | Check migration history table, apply missing migrations in sequence |
+| Schema conflict (column exists) | Make migration idempotent: `IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` |
+| Data integrity violation | Fix data BEFORE applying constraint, or migrate in two steps: add nullable → backfill → add constraint |
+| Failed rollback | Restore from backup, replay forward migrations to known-good point |
+| Enum type conflict (Postgres) | Cannot alter enums in transactions — use `ALTER TYPE` outside transaction block |
+
+**Rule:** Always test migrations on a copy of production data before applying. Use `--dry-run` if available.
+
+## CI/CD Pipeline Fix Patterns
+
+When errors appear only in CI (not locally):
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| `env var not found` | Secret not in CI environment | Add secret to CI settings, reference via `${{ secrets.NAME }}` |
+| Permission denied | Missing IAM role / workflow permissions | Add `permissions:` block to workflow YAML |
+| Timeout | Slow test / missing cache | Add caching step, increase timeout, parallelize jobs |
+| Works locally, fails in CI | OS difference (macOS vs Linux) | Test in Docker matching CI OS; check path case sensitivity |
+| Flaky test in CI | Race condition or timing | Add retry logic, fix async handling, isolate test state |
+| Cache poisoning | Stale cache from broken state | Clear CI cache, add cache key version bump |
+
+## Auto-Detection Reference
+
+| Signal | Detected Type | Verify Command |
+|--------|---------------|----------------|
+| `package.json` has `test` script | test | `npm test` |
+| `tsconfig.json` exists | type | `tsc --noEmit` |
+| `.eslintrc*` or `eslint.config.*` exists | lint | `npx eslint .` |
+| `pyproject.toml` has `pytest` | test | `pytest` |
+| `pyproject.toml` has `mypy` or `ruff` | type + lint | `mypy .`, `ruff check .` |
+| `Cargo.toml` exists | test + lint | `cargo test`, `cargo clippy` |
+| `go.mod` exists | test + lint | `go test ./...`, `golangci-lint run` |
+| `build` script in package.json | build | `npm run build` |
+| `next.config.*` exists | build | `next build` |
+| `vite.config.*` exists | build | `vite build` |
+| `.github/workflows/*.yml` exists | ci | Check latest run: `gh run list --limit 1` |
+| `debug/*/findings.md` exists | bug | Parse findings |
+| `tsc --noEmit` shows `TS2322`, `TS2345` | type error | Fix type mismatch |
+| test output shows `Expected.*Received` | test failure | Fix assertion |
+| build log shows `Module not found` | build failure | Fix import path |
+| CI log shows `exit code 1` | ci | Inspect failed step |
+
+## Chaining Patterns
+
+```bash
+# Debug first, then fix what was found
+/loop 15 /autoresearch:debug
+/loop 30 /autoresearch:fix --from-debug
+
+# Fix with guard
+/autoresearch:fix
+Target: npm run typecheck
+Guard: npm test
+
+# Fix only tests, guard with types
+/autoresearch:fix --category test --guard "tsc --noEmit"
+
+# Fix everything — iterate until clean
+/autoresearch:fix
+
+# Bounded sprint — fix as many as you can in 20 iterations
+/loop 20 /autoresearch:fix
+```
+
+## Output Directory
+
+Creates `fix/{YYMMDD}-{HHMM}-{fix-slug}/` with:
+- `fix-results.tsv` — iteration log
+- `summary.md` — what was fixed, what remains, stats
+- `blocked.md` — errors that needed 3+ attempts and were escalated
+- `impact-assessment.md` — blast radius analysis for each fix applied
+
+## Extended Chaining Patterns
+
+```bash
+# Full pipeline: debug → fix → ship
+/loop 15 /autoresearch:debug
+/loop 30 /autoresearch:fix --from-debug --guard "npm test"
+/autoresearch:ship
+
+# Fix only critical issues, then verify clean
+/autoresearch:fix --category build
+/autoresearch:fix --category type --guard "npm run build"
+/autoresearch:fix --category test --guard "tsc --noEmit"
+
+# Scoped fix with parallel agents
+/autoresearch:fix --scope "src/api/**" --category type
+/autoresearch:fix --scope "src/auth/**" --category test
+
+# Fix with warning suppression disabled
+/autoresearch:fix --category warning --skip-lint
+
+# CI-specific fix: re-run on CI failure
+/autoresearch:fix --target "npm run ci" --guard "npm test"
+
+# After dependency upgrade: fix cascade
+npm upgrade && /autoresearch:fix --category type --category test
+```
+
+## Summary Report Format
+
+```markdown
+# Fix Session Summary
+
+## Stats
+- Session: fix/260316-1805-auth-fixes/
+- Duration: 23 iterations
+- Baseline: 47 errors (31 test, 12 type, 4 lint)
+- Final: 3 errors (2 test, 1 type, 0 lint)
+- Reduction: 93.6% (-44 errors)
+
+## Fix Score
+fix_score: 97/100
+- Reduction: 58/60 (93.6%)
+- Guard: 25/25 (no regressions)
+- Bonus: +10 (zero lint errors)
+- Anti-patterns used: 0
+
+## Fixed
+- auth.ts:42 — add return type annotation (type)
+- db.ts:15 — handle nullable column (type)
+- api.test.ts — fix expected status code 200→201 (test)
+[... 41 more ...]
+
+## Blocked (requires investigation)
+- auth/token-refresh.ts — circular dependency blocks type resolution
+  → Suggested: /autoresearch:debug --scope auth/token-refresh.ts
+
+## Remaining
+- user.test.ts:88 — flaky timing test (not a code bug)
+- config.ts:12 — type error requires breaking API change
+```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,7 +2,7 @@
 
 Real-world examples organized by domain, with practical configurations you can copy-paste.
 
-[Software Engineering](#software-engineering) · [Sales](#sales) · [Marketing](#marketing) · [HR & People Ops](#hr--people-ops) · [Operations](#operations) · [Performance Marketing](#performance-marketing) · [Data Science](#data-science) · [DevOps](#devops) · [Design & Accessibility](#design--accessibility) · [MCP Servers](#combining-with-mcp-servers) · [API Patterns](#combining-with-apis) · [Claude Code Patterns](#claude-code-patterns) · [Plan Wizard Examples](#plan-wizard-examples) · [Security Audit Examples](#security-audit-examples) · [Ship Workflow Examples](#ship-workflow-examples) · [Verification Scripts](#writing-verification-scripts) · [Core Principles](#core-principles)
+[Software Engineering](#software-engineering) · [Sales](#sales) · [Marketing](#marketing) · [HR & People Ops](#hr--people-ops) · [Operations](#operations) · [Performance Marketing](#performance-marketing) · [Data Science](#data-science) · [DevOps](#devops) · [Design & Accessibility](#design--accessibility) · [Debug Examples](#debug-examples) · [Fix Examples](#fix-examples) · [MCP Servers](#combining-with-mcp-servers) · [API Patterns](#combining-with-apis) · [Claude Code Patterns](#claude-code-patterns) · [Plan Wizard Examples](#plan-wizard-examples) · [Security Audit Examples](#security-audit-examples) · [Ship Workflow Examples](#ship-workflow-examples) · [Verification Scripts](#writing-verification-scripts) · [Core Principles](#core-principles)
 
 ---
 
@@ -412,6 +412,186 @@ Goal: Replace all hardcoded colors/spacing with design tokens
 Scope: src/**/*.tsx, src/**/*.css
 Metric: hardcoded values count (lower is better)
 Verify: grep -rE "#[0-9a-fA-F]{3,6}|px\b" src/ --include="*.tsx" --include="*.css" | wc -l
+```
+
+---
+
+## Debug Examples
+
+### Hunt all bugs in a codebase
+
+```
+/autoresearch:debug
+Scope: src/**/*.ts
+```
+
+Claude scans the codebase, runs tests/lint/typecheck, and iteratively investigates every failure using the scientific method — one hypothesis per iteration.
+
+### Debug a specific error
+
+```
+/autoresearch:debug
+Symptom: API returns 500 on POST /users
+Scope: src/api/**/*.ts
+```
+
+### Bounded bug hunt
+
+```
+/loop 20 /autoresearch:debug
+Scope: src/auth/**/*.ts
+```
+
+20 investigation iterations focused on auth code.
+
+### Debug then auto-fix
+
+```
+/autoresearch:debug --fix
+```
+
+Hunts bugs first, then automatically switches to `/autoresearch:fix` to repair everything found.
+
+### Debug by domain
+
+```
+# API debugging — checks routes, middleware, serialization
+/autoresearch:debug
+Scope: src/api/**/*.ts
+Symptom: 404 on valid routes
+
+# Database debugging — checks queries, transactions, N+1
+/autoresearch:debug
+Scope: src/models/**/*.ts
+Symptom: Slow queries on dashboard page
+
+# Auth debugging — checks JWT, permissions, escalation
+/autoresearch:debug
+Scope: src/auth/**/*.ts, src/middleware/**/*.ts
+Symptom: Regular users can access admin endpoints
+```
+
+### Example debug session output
+
+```
+> /loop 10 /autoresearch:debug
+
+[Phase 1] Gathering symptoms...
+  Tests: 3 failures, Lint: 0 errors, Types: 2 errors
+
+[Iteration 1] Hypothesis: "db.insert() missing await at db.ts:88"
+  → CONFIRMED HIGH — silent write failure on error path
+
+[Iteration 2] Hypothesis: "JWT alg not validated at auth.ts:42"
+  → CONFIRMED CRITICAL — algorithm confusion vulnerability
+
+[Iteration 3] Hypothesis: "Rate limiting missing on /api/auth/login"
+  → CONFIRMED MEDIUM — brute force possible
+
+[Iteration 4] Hypothesis: "SQL injection via string concat in search"
+  → DISPROVEN — parameterized queries used correctly
+
+=== Debug Complete (10/10 iterations) ===
+Bugs found: 3 (1 Critical, 1 High, 1 Medium)
+Hypotheses: 10 tested (3 confirmed, 6 disproven, 1 inconclusive)
+Files investigated: 14 / 47 in scope
+```
+
+---
+
+## Fix Examples
+
+### Fix all errors automatically
+
+```
+/autoresearch:fix
+```
+
+Auto-detects what's broken (tests, types, lint, build), prioritizes by severity, and fixes ONE thing per iteration until zero errors.
+
+### Fix with guard
+
+```
+/autoresearch:fix
+Target: tsc --noEmit
+Guard: npm test
+```
+
+Fixes type errors while ensuring tests keep passing.
+
+### Fix only tests
+
+```
+/autoresearch:fix --category test
+```
+
+### Fix only TypeScript errors
+
+```
+/autoresearch:fix --category type --guard "npm test"
+```
+
+### Fix from debug findings
+
+```
+# Step 1: Hunt bugs
+/loop 15 /autoresearch:debug
+
+# Step 2: Fix what was found
+/loop 30 /autoresearch:fix --from-debug
+```
+
+### Bounded fix sprint
+
+```
+/loop 20 /autoresearch:fix
+```
+
+Fix as many errors as possible in 20 iterations.
+
+### Example fix session output
+
+```
+> /autoresearch:fix
+
+[Phase 1] Detected: 47 test failures, 12 type errors, 3 lint errors
+[Phase 2] Priority: types first (may cascade-fix test failures)
+
+[Iteration 1] Fix: auth.ts:42 — add return type annotation
+  delta: -2 errors | guard: pass | STATUS: KEEP
+
+[Iteration 2] Fix: db.ts:15 — handle nullable column
+  delta: -1 error | guard: pass | STATUS: KEEP
+
+[Iteration 3] Fix: api.test.ts — fix expected status 200→201
+  delta: -3 errors | guard: pass | STATUS: KEEP
+
+[Iteration 4] Fix: auth.test.ts — wrong approach
+  delta: 0 errors | guard: - | STATUS: DISCARD (reverted)
+
+...
+
+=== Fix Complete (23 iterations) ===
+Baseline: 62 errors → Final: 3 errors (-95.2%)
+Keeps: 19 | Discards: 3 | Reworks: 1
+Blocked: 1 (circular dependency — escalated to /autoresearch:debug)
+```
+
+### Fix CI/CD failures
+
+```
+/autoresearch:fix
+Target: gh run view --log-failed
+Scope: .github/workflows/*.yml
+```
+
+### Fix after dependency upgrade
+
+```
+/autoresearch:fix
+Target: npm test
+Guard: tsc --noEmit
+Scope: src/**/*.ts
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 [![Follow @iuditg](https://img.shields.io/badge/Follow-@iuditg-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/follow?screen_name=iuditg)
@@ -84,6 +84,8 @@ Before looping, Claude performs a one-time setup:
 | `/autoresearch:plan` | Interactive wizard: Goal → Scope, Metric, Verify config |
 | `/autoresearch:security` | Autonomous STRIDE + OWASP + red-team security audit |
 | `/autoresearch:ship` | Universal shipping workflow (code, content, marketing, sales, research, design) |
+| `/autoresearch:debug` | Autonomous bug-hunting loop — scientific method + iterative investigation |
+| `/autoresearch:fix` | Autonomous fix loop — iteratively repair errors until zero remain |
 | `Guard: <command>` | Optional safety net — must pass for changes to be kept |
 
 ### Quick Decision Guide
@@ -95,6 +97,9 @@ Before looping, Claude performs a one-time setup:
 | Run a security audit | `/autoresearch:security` |
 | Ship a PR / deployment / release | `/autoresearch:ship` |
 | Optimize without breaking existing tests | Add `Guard: npm test` |
+| Hunt all bugs in a codebase | `/autoresearch:debug` or `/loop 20 /autoresearch:debug` |
+| Fix all errors (tests, types, lint) | `/autoresearch:fix` |
+| Debug then auto-fix | `/autoresearch:debug --fix` |
 | Check if something is ready to ship | `/autoresearch:ship --checklist-only` |
 
 ---
@@ -215,6 +220,52 @@ Auto-detects what you're shipping (code PR, deployment, blog post, email campaig
 
 ---
 
+## /autoresearch:debug — Autonomous Bug Hunter (v1.3.0)
+
+Scientific method meets autoresearch loop. Doesn't stop at one bug — iteratively hunts ALL bugs using falsifiable hypotheses, evidence-based investigation, and 7 investigation techniques.
+
+```
+/loop 20 /autoresearch:debug
+Scope: src/api/**/*.ts
+Symptom: API returns 500 on POST /users
+```
+
+**How it works:** Gather symptoms → Recon (map error surface) → Hypothesize (specific, testable) → Test (one experiment per iteration) → Classify (confirmed/disproven/inconclusive) → Log → Repeat.
+
+Every finding requires **code evidence** (file:line + reproduction steps). Every disproven hypothesis is logged — equally valuable. Uses 7 techniques: binary search, differential debugging, minimal reproduction, trace execution, pattern search, working backwards, rubber duck.
+
+| Flag | Purpose |
+|------|---------|
+| `--fix` | After hunting, auto-switch to `/autoresearch:fix` |
+| `--scope <glob>` | Limit investigation scope |
+| `--symptom "<text>"` | Pre-fill symptom |
+| `--severity <level>` | Minimum severity to report |
+
+---
+
+## /autoresearch:fix — Autonomous Error Crusher (v1.3.0)
+
+Takes a broken state and iteratively repairs it until everything passes. ONE fix per iteration. Atomic, committed, verified, auto-reverted on failure.
+
+```
+/autoresearch:fix
+```
+
+**How it works:** Auto-detects what's broken (tests, types, lint, build) → Prioritizes (blockers first) → Fixes ONE thing → Commits → Verifies error count decreased → Guard check (no regressions) → Keep/Revert → Repeat until zero errors.
+
+**Stops automatically when error count hits zero** — even in unbounded mode.
+
+| Flag | Purpose |
+|------|---------|
+| `--target <command>` | Explicit verify command |
+| `--guard <command>` | Safety command that must always pass |
+| `--category <type>` | Only fix specific type (test, type, lint, build) |
+| `--from-debug` | Read findings from latest debug session |
+
+**Chain them:** `/loop 15 /autoresearch:debug` then `/loop 30 /autoresearch:fix --from-debug`
+
+---
+
 ## Guard — Prevent Regressions (v1.0.4)
 
 When optimizing a metric, the loop might break existing behavior. **Guard** is an optional safety net.
@@ -277,7 +328,9 @@ autoresearch/
 │   └── autoresearch/
 │       ├── ship.md                                ← /autoresearch:ship registration
 │       ├── plan.md                                ← /autoresearch:plan registration
-│       └── security.md                            ← /autoresearch:security registration
+│       ├── security.md                            ← /autoresearch:security registration
+│       ├── debug.md                               ← /autoresearch:debug registration
+│       └── fix.md                                 ← /autoresearch:fix registration
 └── skills/
     └── autoresearch/
         ├── SKILL.md                               ← Main skill (loaded by Claude Code)
@@ -287,6 +340,8 @@ autoresearch/
             ├── plan-workflow.md                   ← Plan wizard protocol
             ├── security-workflow.md               ← Security audit protocol
             ├── ship-workflow.md                   ← Ship workflow protocol
+            ├── debug-workflow.md                  ← Debug loop protocol
+            ├── fix-workflow.md                    ← Fix loop protocol
             └── results-logging.md                 ← TSV tracking format
 ```
 

--- a/commands/autoresearch/debug.md
+++ b/commands/autoresearch/debug.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:debug
+description: Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
+argument-hint: "[--fix] [--scope <glob>] [--symptom <text>] [--severity <level>]"
+---
+
+Load and follow the autoresearch debug workflow protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the debug workflow reference: `.claude/skills/autoresearch/references/debug-workflow.md` — this is the FULL protocol to follow
+3. Parse any flags from the user's arguments: $ARGUMENTS
+4. Execute the 7-phase debug loop as defined in `debug-workflow.md`
+
+Follow the debug workflow protocol exactly. Every finding requires code evidence (file:line + reproduction steps). Every disproven hypothesis is logged — equally valuable.

--- a/commands/autoresearch/fix.md
+++ b/commands/autoresearch/fix.md
@@ -1,0 +1,14 @@
+---
+name: autoresearch:fix
+description: Autonomous fix loop — iteratively repairs errors until zero remain. One fix per iteration, atomic, auto-reverted on failure.
+argument-hint: "[--target <cmd>] [--guard <cmd>] [--scope <glob>] [--category <type>] [--from-debug]"
+---
+
+Load and follow the autoresearch fix workflow protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the overall autoresearch framework
+2. Read the fix workflow reference: `.claude/skills/autoresearch/references/fix-workflow.md` — this is the FULL protocol to follow
+3. Parse any flags from the user's arguments: $ARGUMENTS
+4. Execute the 8-phase fix loop as defined in `fix-workflow.md`
+
+Follow the fix workflow protocol exactly. ONE fix per iteration. Never suppress errors. Fix implementation, not tests. Auto-revert on regression.

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.2.0
+version: 1.3.0
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
@@ -18,6 +18,8 @@ Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch).
 | `/autoresearch:plan` | Interactive wizard to build Scope, Metric, Direction & Verify from a Goal |
 | `/autoresearch:security` | Autonomous security audit: STRIDE threat model + OWASP Top 10 + red-team (4 adversarial personas) |
 | `/autoresearch:ship` | Universal shipping workflow: ship code, content, marketing, sales, research, or anything |
+| `/autoresearch:debug` | Autonomous bug-hunting loop: scientific method + iterative investigation until codebase is clean |
+| `/autoresearch:fix` | Autonomous fix loop: iteratively repair errors (tests, types, lint, build) until zero remain |
 
 ### /autoresearch:security — Autonomous Security Audit (v1.0.3)
 
@@ -211,6 +213,10 @@ After the wizard completes, the user gets a ready-to-paste `/autoresearch` invoc
 - User says "security audit", "threat model", "OWASP", "STRIDE", "find vulnerabilities", "red-team" → run the security audit
 - User invokes `/autoresearch:ship` → run the ship workflow
 - User says "ship it", "deploy this", "publish this", "launch this", "get this out the door" → run the ship workflow
+- User invokes `/autoresearch:debug` → run the debug loop
+- User says "find all bugs", "hunt bugs", "debug this", "why is this failing", "investigate" → run the debug loop
+- User invokes `/autoresearch:fix` → run the fix loop
+- User says "fix all errors", "make tests pass", "fix the build", "clean up errors" → run the fix loop
 - User says "work autonomously", "iterate until done", "keep improving", "run overnight" → run the loop
 - Any task requiring repeated iteration cycles with measurable outcomes → run the loop
 
@@ -321,5 +327,7 @@ See `references/core-principles.md` for the 7 generalizable principles from auto
 | Refactoring | Tests pass + LOC reduced | Target module | `npm test && wc -l` | `npm run typecheck` |
 | Security | OWASP + STRIDE coverage + findings | API/auth/middleware | `/autoresearch:security` | — |
 | Shipping | Checklist pass rate (%) | Any artifact | `/autoresearch:ship` | Domain-specific |
+| Debugging | Bugs found + coverage | Target files | `/autoresearch:debug` | — |
+| Fixing | Error count (lower) | Target files | `/autoresearch:fix` | `npm test` |
 
 Adapt the loop to your domain. The PRINCIPLES are universal; the METRICS are domain-specific.

--- a/skills/autoresearch/references/debug-workflow.md
+++ b/skills/autoresearch/references/debug-workflow.md
@@ -1,0 +1,442 @@
+# Debug Workflow — /autoresearch:debug
+
+Autonomous bug-hunting loop that applies the scientific method iteratively. Doesn't stop at one bug — keeps investigating until the codebase is clean or you interrupt.
+
+**Core idea:** Hypothesize → Test → Prove/Disprove → Log → Repeat. Every finding needs code evidence. Every failed hypothesis teaches the next one.
+
+## Trigger
+
+- User invokes `/autoresearch:debug`
+- User says "find all bugs", "debug this", "why is this failing", "hunt bugs", "investigate"
+- User reports a specific error and wants root cause analysis
+
+## Loop Support
+
+```
+# Unlimited — keep hunting bugs until interrupted
+/autoresearch:debug
+
+# Bounded — exactly N investigation iterations
+/loop 20 /autoresearch:debug
+
+# Focused scope
+/autoresearch:debug
+Scope: src/api/**/*.ts
+Symptom: API returns 500 on POST /users
+```
+
+## Architecture
+
+```
+/autoresearch:debug
+  ├── Phase 1: Gather (symptoms + context)
+  ├── Phase 2: Reconnaissance (scan codebase, map error surface)
+  ├── Phase 3: Hypothesize (form falsifiable hypothesis)
+  ├── Phase 4: Test (run experiment to prove/disprove)
+  ├── Phase 5: Classify (bug found / hypothesis disproven / inconclusive)
+  ├── Phase 6: Log (record finding or elimination)
+  └── Phase 7: Repeat (next hypothesis, next vector)
+```
+
+## Phase 1: Gather — Symptoms & Context
+
+Collect everything known about the problem before investigating.
+
+**If user provides symptoms:**
+- Expected behavior vs actual behavior
+- Error messages, stack traces, log output
+- When it started (commit, deploy, config change)
+- Reproduction steps (if known)
+- Environment (OS, runtime, versions)
+
+**If no symptoms (autonomous bug hunting):**
+- Run existing test suite, collect failures
+- Run linter, collect errors
+- Run type checker, collect issues
+- Check build, collect warnings
+- Scan for common anti-patterns (unhandled promises, unchecked nulls, race conditions)
+
+**Output:** `✓ Phase 1: Gathered — [N] symptoms, [M] error signals detected`
+
+## Phase 2: Reconnaissance — Map the Error Surface
+
+Understand the codebase area where bugs likely live.
+
+**Actions:**
+1. Read files mentioned in stack traces / error messages
+2. Trace call chains from error origin backward
+3. Identify entry points (API routes, event handlers, CLI commands)
+4. Map data flow through affected components
+5. Check recent git changes in affected area (`git log --oneline -20 -- <path>`)
+6. Identify external dependencies and integration points
+
+**Error surface map:**
+```
+Entry Point → Data Flow → Failure Point → Side Effects
+  POST /users → validate() → db.insert() → ← FAILS HERE
+                                             → notification.send() ← cascading
+```
+
+**Output:** `✓ Phase 2: Recon — [N] files scanned, [M] potential failure points mapped`
+
+## Phase 3: Hypothesize — Form Falsifiable Hypothesis
+
+**A good hypothesis is:**
+- Specific: "The JWT validation skips algorithm check on line 42 of auth.ts"
+- Testable: Can be proven/disproven with a concrete experiment
+- Falsifiable: There exists evidence that would prove it wrong
+- Prioritized: Most likely cause first (based on evidence so far)
+
+**Hypothesis formation strategy:**
+
+| Priority | Strategy | When to Use |
+|----------|----------|-------------|
+| 1 | **Error message literal** | Stack trace points to exact line |
+| 2 | **Recent change** | Bug started after specific commit |
+| 3 | **Data flow trace** | Input → Transform → Output chain |
+| 4 | **Environment diff** | Works locally, fails in CI/prod |
+| 5 | **Dependency issue** | After upgrade/install |
+| 6 | **Race condition** | Intermittent, timing-dependent |
+| 7 | **Edge case** | Works for most inputs, fails for specific ones |
+
+**Cognitive bias guards:**
+- Confirmation bias: Actively seek evidence AGAINST your hypothesis
+- Anchoring: Don't fixate on the first clue — consider alternatives
+- Sunk cost: If 3 experiments fail to confirm, abandon and try new hypothesis
+- Availability: Just because a bug pattern is familiar doesn't mean it's the cause
+
+**Output:** `Hypothesis [N]: "[specific, testable claim]" — testing...`
+
+## Phase 4: Test — Run Experiment
+
+Design a minimal experiment that definitively proves or disproves the hypothesis.
+
+**Experiment types:**
+
+| Type | Method | Best For |
+|------|--------|----------|
+| **Direct inspection** | Read the code at suspected location | Logic errors, missing checks |
+| **Trace execution** | Add logging, run, read output | Data flow issues |
+| **Minimal reproduction** | Create smallest failing case | Complex interactions |
+| **Binary search** | Comment out half the code, narrow | "Something in this file breaks" |
+| **Differential** | Compare working vs broken (git diff, env diff) | Regressions |
+| **Git bisect** | Find exact commit that introduced bug | "It used to work" |
+| **Input variation** | Change inputs systematically | Edge cases, boundary issues |
+
+**Experiment rules:**
+- ONE experiment per iteration (atomic — know exactly what you tested)
+- Record the exact command/action and its output
+- If experiment is destructive, git stash first
+- Timeout: if an experiment takes >30 seconds, it's too complex — simplify
+
+## Phase 5: Classify — What Did We Learn?
+
+| Result | Action |
+|--------|--------|
+| **Bug confirmed** | Record finding with full evidence, severity, location |
+| **Hypothesis disproven** | Log as eliminated, extract learnings for next hypothesis |
+| **Inconclusive** | Refine hypothesis with additional constraints, re-test |
+| **New lead discovered** | Log discovery, add to hypothesis queue |
+
+**Bug finding format:**
+```
+### [SEVERITY] Bug: [title]
+- **Location:** `file:line`
+- **Hypothesis:** [what we suspected]
+- **Evidence:** [code snippet + experiment result]
+- **Reproduction:** [exact steps to trigger]
+- **Impact:** [what breaks, who's affected]
+- **Root cause:** [WHY it happens, not just WHAT happens]
+- **Suggested fix:** [concrete code change]
+```
+
+**Severity classification:**
+| Level | Criteria |
+|-------|----------|
+| CRITICAL | Data loss, security breach, system crash |
+| HIGH | Feature broken, incorrect results, performance degradation >10x |
+| MEDIUM | Edge case failure, degraded UX, workaround exists |
+| LOW | Cosmetic, minor inconsistency, theoretical risk |
+
+## Phase 6: Log — Record Everything
+
+**Append to debug-results.tsv:**
+```tsv
+iteration	type	hypothesis	result	severity	location	description
+1	hypothesis	JWT skips alg check	confirmed	CRITICAL	auth.ts:42	Algorithm confusion vulnerability
+2	hypothesis	Rate limit missing	disproven	-	-	Rate limiter exists in middleware
+3	discovery	-	new_lead	-	db.ts:88	Unhandled promise rejection in insert
+4	hypothesis	DB insert missing await	confirmed	HIGH	db.ts:88	Silent failure on write errors
+```
+
+**Every 5 iterations, print progress:**
+```
+=== Debug Progress (iteration 10) ===
+Bugs found: 3 (1 Critical, 1 High, 1 Medium)
+Hypotheses tested: 8 (3 confirmed, 4 disproven, 1 inconclusive)
+Files investigated: 14 / 47 in scope
+Techniques used: direct inspection, trace, binary search
+```
+
+## Phase 7: Repeat — Next Investigation
+
+**Prioritization for next iteration:**
+1. Follow new leads discovered during previous experiments
+2. Untested high-priority hypotheses
+3. Uninvestigated files in the error surface
+4. Deeper investigation of confirmed bugs (find root cause, not just symptom)
+5. Pattern-based search (if found NULL check bug, look for similar patterns elsewhere)
+
+**When to stop (unbounded mode):**
+- Never stop automatically — user interrupts
+- Print a "diminishing returns" warning after 5 iterations with no new findings
+
+**When to stop (bounded mode):**
+- After N iterations, print final summary and stop
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--fix` | After finding bugs, switch to autoresearch:fix mode to fix them |
+| `--scope <glob>` | Limit investigation to specific files |
+| `--symptom "<text>"` | Pre-fill symptom instead of asking |
+| `--severity <level>` | Only report findings at or above this severity |
+| `--technique <name>` | Force a specific investigation technique |
+
+## Composite Metric
+
+For bounded loops, the debug thoroughness metric:
+
+```
+debug_score = bugs_found * 15
+            + hypotheses_tested * 3
+            + (files_investigated / files_in_scope) * 40
+            + (techniques_used / 7) * 10
+```
+
+Higher = more thorough. Incentivizes breadth (cover more files) AND depth (test more hypotheses).
+
+## Investigation Techniques Reference
+
+### Binary Search
+Comment out half the suspicious code. If bug disappears, it's in that half. Repeat.
+
+### Differential Debugging
+Compare working state vs broken state:
+- `git stash` to test clean state
+- `git bisect` to find exact breaking commit
+- Environment variables diff between working/failing environments
+
+### Minimal Reproduction
+Strip away everything until you have the smallest possible case that reproduces the bug. Fewer moving parts = clearer cause.
+
+### Trace Execution
+Add strategic console.log/print statements at key data flow points. Run and read the actual values vs expected values.
+
+### Pattern Search
+Found one bug? Search for the same anti-pattern across the codebase:
+```bash
+grep -rn "pattern" src/ --include="*.ts"
+```
+
+### Working Backwards
+Start from the error (output) and trace backward through the code until you find where correct behavior diverges from actual behavior.
+
+### Rubber Duck
+Explain the code out loud, line by line. The act of explaining often reveals the assumption that's wrong.
+
+## Common Bug Patterns by Language
+
+Quick reference for language-specific bugs to scan for during reconnaissance.
+
+| Language | Classic Bug | Pattern to Search | Why It Happens |
+|----------|-------------|-------------------|----------------|
+| **JavaScript** | Unhandled promise rejection | `Promise` without `.catch` / missing `await` | Async errors are swallowed silently |
+| **TypeScript** | `undefined` access after null check narrowing | `obj?.prop` then `obj.other` (lost narrowing) | Type narrowing is scope-limited |
+| **Python** | Mutable default argument | `def f(x=[]):` — shared across all calls | Python evaluates defaults once at definition time |
+| **Python** | `None` injection from unchecked return | Function returns `None` on error path, caller chains it | Missing null/None guard |
+| **Go** | Goroutine leak | Goroutine blocks on channel that's never closed | Missing `defer close(ch)` or `context.Cancel()` |
+| **Go** | Race condition on shared map | Concurrent read/write without mutex | Maps in Go are not goroutine-safe |
+| **Go** | Integer overflow in slice/buffer ops | `int` size differences on 32-bit vs 64-bit | Implicit numeric type assumptions |
+| **Rust** | Panic in production from `.unwrap()` | `Option::unwrap()` / `Result::unwrap()` on `Err` | Error path not handled |
+| **Java** | `NullPointerException` cascade | Unguarded method chain `a.b().c().d()` | No null checks in chain |
+| **Java** | SQL injection via string concat | `"SELECT * FROM t WHERE id=" + id` | Missing parameterized queries |
+| **SQL** | N+1 query | Loop calling DB inside loop | Missing JOIN or batch fetch |
+| **All** | Race condition on shared state | Global/singleton mutated from concurrent threads | Missing synchronization |
+| **All** | Integer overflow in calculations | Arithmetic on large numbers without bounds check | Silent wrap-around on overflow |
+| **All** | Injection vulnerability | User input concatenated into command/query/template | Missing sanitization/escaping |
+
+**Reconnaissance shortcut:** When entering Phase 2, grep for these patterns first — they're statistically the most common issues.
+
+## Domain-Specific Debugging
+
+Different domains have predictable failure modes. Apply domain-specific reconnaissance before forming hypotheses.
+
+### API Bugs
+
+Common failure points: auth middleware order, content-type mismatch, serialization/deserialization, HTTP status code semantics.
+
+**API debug checklist:**
+- Does the route exist and match the HTTP method?
+- Is auth middleware applied and in the correct order?
+- Does the request body parse correctly (Content-Type header)?
+- Are 4xx responses distinguishable from 5xx? Is error shape consistent?
+- Are query parameters validated and typed correctly?
+
+### Database Bugs
+
+Common failure points: N+1 queries, missing transactions, constraint violations swallowed by ORM, timezone handling, NULL propagation.
+
+**Database debug checklist:**
+- Are all writes wrapped in transactions where atomicity is needed?
+- Are NULL values handled at the DB and application layer?
+- Is the query hitting an index? (check with `EXPLAIN`)
+- Is connection pooling exhausted? (check connection count vs pool limit)
+- Are timestamps stored as UTC? Converted correctly on read?
+
+### Authentication / Authorization Bugs
+
+Common failure points: token validation skipping algorithm check, expired token not rejected, privilege escalation from missing ownership check.
+
+**Auth debug checklist:**
+- Is the JWT `alg` field validated (prevent algorithm confusion attacks)?
+- Is token expiry (`exp`) checked?
+- Is authorization (ownership check) separate from authentication (identity check)?
+- Are there privilege escalation paths (e.g., regular user accessing admin endpoint)?
+
+### Async / Concurrency Bugs
+
+Common failure points: race conditions on shared state, missing await causing partial execution, event loop blocking, deadlock.
+
+**Async debug checklist:**
+- Is every `async` function `await`ed at the call site?
+- Are shared mutable state accesses synchronized (mutex, lock, atomic)?
+- Is there a risk of deadlock (two locks acquired in different orders)?
+- Are network/database calls inside async handlers non-blocking?
+
+### Network / Integration Bugs
+
+Common failure points: timeout misconfiguration, retry storm on transient failure, missing circuit breaker, charset encoding mismatch.
+
+**Network debug checklist:**
+- Are timeouts set on all outbound calls?
+- Is retry logic bounded (exponential backoff with max retries)?
+- Is response parsing resilient to unexpected fields?
+- Are character encoding assumptions explicit (UTF-8 everywhere)?
+
+## What NOT to Do — Debug Anti-Patterns
+
+| Anti-Pattern | Why It Fails |
+|---|---|
+| **Fix before understanding** | You'll fix symptoms, not causes. The bug comes back. |
+| **Change multiple things at once** | Can't attribute improvement/regression to any single change. |
+| **Ignore disproven hypotheses** | Not logging eliminations means repeating failed investigations. |
+| **Assume instead of verify** | "It's probably X" without testing = confirmation bias. Run the experiment. |
+| **Skip reproduction** | If you can't reproduce it, you can't verify the fix. |
+| **Debug in production** | Never investigate with live data. Reproduce locally first. |
+| **Tunnel vision on one file** | Bugs often span boundaries. Trace the full data flow. |
+| **Trust error messages literally** | Error messages describe symptoms. Root cause is often 2-3 layers deeper. |
+| **Give up after 3 tries** | Some bugs need 10+ hypotheses. Shift technique, don't stop. |
+| **Blame the framework** | 95% of the time it's your code. Prove framework bug with minimal reproduction first. |
+
+## Multi-File Bug Tracing
+
+When a bug spans multiple files or services, standard single-file inspection fails. Use a structured cross-file trace.
+
+**When to apply:**
+- Stack trace crosses multiple files/modules
+- Bug involves data transformation across service boundaries
+- Fix in one file doesn't resolve the issue (symptom vs cause)
+
+**Protocol:**
+1. Start at the symptom (error output or failing assertion)
+2. Trace backwards across file boundaries: identify the data/call flowing in
+3. For each file in the trace, record: what goes in, what comes out, where it transforms
+4. Identify the first file where the output diverges from the expected contract
+5. That file owns the bug — even if it's not where the error surfaces
+
+**Multi-file trace map format:**
+```
+file-a.ts → file-b.ts → file-c.ts → ERROR
+  input: {...}  transform: {...}  output: WRONG
+         ^first divergence = root cause lives here
+```
+
+**Across microservices:** Add network boundaries to the map. Include request/response payloads at each service boundary. A bug "in service B" often means service A sent malformed data.
+
+## Performance Bug Investigation
+
+Performance bugs are correctness bugs where the output is "too slow" rather than "wrong". Apply the same scientific method with profiling as the measurement tool.
+
+**Profiling first, guessing second:**
+- Profile before optimizing — the slow part is almost never where you think
+- Identify the single hottest path (slow query, slow render, slow computation)
+- Reproduce the slowness with a minimal benchmark before attempting a fix
+
+**Performance issue patterns:**
+| Symptom | Likely Cause | Investigation Method |
+|---------|--------------|---------------------|
+| Slow API response | N+1 database queries | Log SQL queries, count DB calls per request |
+| Slow page render | Expensive recomputation on every render | Profiling (React DevTools, Chrome DevTools) |
+| Slow background job | Missing index on query inside loop | `EXPLAIN ANALYZE` on repeated queries |
+| Gradual memory growth | Memory leak (event listeners, unclosed connections) | Heap snapshots over time |
+| Slow cold start | Over-importing, large bundle, slow init code | Bundle analyzer, startup profiling |
+| Intermittent slow requests | Lock contention or connection pool exhaustion | DB slow query log, connection pool metrics |
+
+**Performance debug checklist:**
+1. Measure baseline (p50, p95, p99 latency or total time)
+2. Profile to find the actual hotspot (not the assumed one)
+3. Form hypothesis: "removing X will reduce Y by Z%"
+4. Implement ONE change, re-measure
+5. Verify improvement is statistically significant (not noise)
+
+## The 5 Whys — Root Cause Drill-Down
+
+Surface errors rarely reveal root causes. Ask "why" recursively until you reach a fundamental cause you can permanently fix.
+
+**Template:**
+```
+Symptom: [what the user/system reported]
+Why 1: [immediate technical cause]
+Why 2: [cause of the cause]
+Why 3: [deeper system issue]
+Why 4: [process or design flaw]
+Why 5: [root cause — fixable permanently]
+```
+
+**Example:**
+```
+Symptom: API returns 500 on POST /users
+Why 1: database insert throws ConstraintViolationError
+Why 2: email field is empty string, violates NOT NULL constraint
+Why 3: validation layer allows empty strings as valid email
+Why 4: validation uses truthy check (empty string is falsy — wait, it isn't)
+Why 5: regex validator has a bug — accepts empty string as valid email format
+Root Fix: fix the email regex to require at least one character before @
+```
+
+**Stop when:** The why leads to an external system outside your control, a deliberate design decision, or a hardware/infrastructure limit. Those get a workaround, not a root fix.
+
+**Stop asking why if:** You reach a fix that prevents ALL future instances of this class of bug — not just this specific instance.
+
+## Output Directory
+
+Creates `debug/{YYMMDD}-{HHMM}-{debug-slug}/` with:
+- `findings.md` — all confirmed bugs with evidence
+- `eliminated.md` — disproven hypotheses (equally valuable)
+- `debug-results.tsv` — iteration log
+- `summary.md` — executive summary with recommendations
+
+## Chaining with /autoresearch:fix
+
+```
+# Find bugs, then fix them
+/autoresearch:debug --fix
+
+# Or manually chain
+/loop 15 /autoresearch:debug    # hunt bugs
+/loop 20 /autoresearch:fix      # fix everything found
+```
+
+When `--fix` is specified, after the debug loop completes, automatically switches to `/autoresearch:fix` targeting the discovered issues.

--- a/skills/autoresearch/references/fix-workflow.md
+++ b/skills/autoresearch/references/fix-workflow.md
@@ -1,0 +1,650 @@
+# Fix Workflow — /autoresearch:fix
+
+Autonomous fix loop that takes a broken state and iteratively repairs it until everything passes. One fix per iteration. Atomic, committed, verified, auto-reverted on failure.
+
+**Core idea:** Detect → Prioritize → Fix ONE thing → Verify → Keep/Revert → Repeat until zero errors.
+
+## Trigger
+
+- User invokes `/autoresearch:fix`
+- User says "fix all errors", "make tests pass", "fix the build", "clean up all warnings"
+- User has output from `/autoresearch:debug` and wants to fix the findings
+
+## Loop Support
+
+```
+# Unlimited — keep fixing until everything passes
+/autoresearch:fix
+
+# Bounded — exactly N fix iterations
+/loop 30 /autoresearch:fix
+
+# With explicit target
+/autoresearch:fix
+Target: make all tests pass
+Scope: src/**/*.ts
+Guard: npm run typecheck
+```
+
+## Architecture
+
+```
+/autoresearch:fix
+  ├── Phase 1: Detect (what's broken?)
+  ├── Phase 2: Prioritize (fix order)
+  ├── Phase 3: Fix ONE thing (atomic change)
+  ├── Phase 4: Commit (before verification)
+  ├── Phase 5: Verify (did error count decrease?)
+  ├── Phase 6: Guard (did anything else break?)
+  ├── Phase 7: Decide (keep / revert / rework)
+  └── Phase 8: Log & Repeat
+```
+
+## Phase 1: Detect — What's Broken?
+
+Auto-detect the failure domain from context, or accept explicit target.
+
+**Detection algorithm:**
+```
+FUNCTION detectFailures(context):
+  failures = []
+
+  # Run test suite
+  IF test runner detected (jest, pytest, vitest, go test, cargo test):
+    result = run_tests()
+    IF failures → ADD {type: "test", count: N, details: [...]}
+
+  # Run type checker
+  IF typescript detected:
+    result = run("tsc --noEmit")
+    IF errors → ADD {type: "type", count: N, details: [...]}
+
+  # Run linter
+  IF linter detected (eslint, ruff, clippy):
+    result = run_lint()
+    IF errors → ADD {type: "lint", count: N, details: [...]}
+
+  # Run build
+  IF build script detected:
+    result = run_build()
+    IF fails → ADD {type: "build", count: 1, details: [...]}
+
+  # Check for debug findings
+  IF debug/{latest}/findings.md exists:
+    bugs = parse_findings()
+    ADD {type: "bug", count: N, details: [...]}
+
+  # Check CI
+  IF .github/workflows/ exists:
+    IF user mentions CI failure → ADD {type: "ci", count: 1, details: [...]}
+
+  # Detect warnings (lower priority but tracked)
+  IF warning-level output detected:
+    result = run_warnings()
+    IF warnings → ADD {type: "warning", count: N, details: [...]}
+
+  RETURN failures sorted by severity
+```
+
+**Output:** `✓ Phase 1: Detected — [N] test failures, [M] type errors, [K] lint errors, [W] warnings`
+
+**Detection priority note:** Run build first — if build fails, type/test/lint results are unreliable. Warnings are detected last; {type: "warning"} items go to lowest priority queue.
+
+## Phase 2: Prioritize — Fix Order
+
+Fix in this order (blockers first, polish last):
+
+| Priority | Category | Why First |
+|----------|----------|-----------|
+| 1 | **Build failures** | Nothing works if it doesn't compile |
+| 2 | **Critical/High bugs** | From debug findings — data loss, security |
+| 3 | **Type errors** | Type safety prevents cascading bugs |
+| 4 | **Test failures** | Tests verify correctness |
+| 5 | **Medium/Low bugs** | From debug findings |
+| 6 | **Lint errors** | Code quality |
+| 7 | **Warnings** | Polish — type "warning" in detection |
+
+**Within a category, prioritize by:**
+1. Cascading impact (fixing one may fix others downstream)
+2. Simplicity (quick wins first — build momentum)
+3. File locality (fixes in same file grouped)
+
+**Output:** `✓ Phase 2: Prioritized — fixing [category] first ([N] items)`
+
+## Phase 3: Fix ONE Thing — Atomic Change
+
+Pick the highest-priority unfixed item and make ONE focused change.
+
+**Fix strategies by category:**
+
+| Category | Strategy |
+|----------|----------|
+| Build failure | Read error, fix the exact line/import/config |
+| Type error | Add proper types, fix signatures, handle null cases |
+| Test failure | Read test + implementation, find mismatch, fix implementation (not test) |
+| Lint error | Apply the rule — auto-fix where possible |
+| Bug (from debug) | Apply the suggested fix from findings.md |
+| Warning | Resolve the underlying issue, don't suppress |
+
+**Fix Strategies by Language:**
+
+| Language | Never Do | Correct Pattern |
+|----------|----------|-----------------|
+| TypeScript | `any`, `@ts-ignore`, type assertions to bypass | Proper interfaces, generics, discriminated unions |
+| Python | Bare `except:`, missing type hints on public API | `except SpecificError:`, full type hints with `from __future__ import annotations` |
+| Go | Ignoring errors with `_`, `panic` in library code | Explicit error wrapping `fmt.Errorf("context: %w", err)`, propagate with context |
+| Rust | `.unwrap()` in production, silencing `#[allow(unused)]` | `Result<T, E>` propagation with `?`, custom error types with `thiserror` |
+| Java | Swallowing exceptions, raw types | Typed exceptions, generics, checked exception handling |
+
+**Rules:**
+- ONE fix per iteration. Not two. Not "while I'm here."
+- Fix the IMPLEMENTATION, not the test (unless the test is genuinely wrong)
+- Never add `@ts-ignore`, `eslint-disable`, `# type: ignore` to suppress errors
+- Never use any|any escape hatch never solves type errors — use proper narrowed types or generics
+- Never delete test|delete test coverage never improves code — fix the implementation to satisfy tests
+- Prefer minimal changes — smallest diff that fixes the issue
+
+## Phase 4: Commit — Before Verification
+
+```bash
+git add -A
+git commit -m "fix: [what was fixed] — [file:line]"
+```
+
+Commit BEFORE running verification. This enables clean rollback if the fix breaks something.
+
+## Phase 5: Verify — Did It Help?
+
+Re-run the detection from Phase 1 and compare:
+
+```
+previous_errors = error_count_before
+current_errors = error_count_after
+
+delta = previous_errors - current_errors
+```
+
+**Expected:** `delta > 0` (fewer errors than before)
+
+## Phase 6: Guard — Did Anything Else Break?
+
+If a guard command is specified, run it:
+
+```
+guard_result = run(guard_command)  # e.g., "npm test"
+```
+
+**Guard prevents regressions.** Fixing a type error shouldn't break a test. Fixing a test shouldn't break the build.
+
+## Phase 7: Decide — Keep, Revert, or Rework
+
+| Condition | Action |
+|-----------|--------|
+| `delta > 0` AND guard passes | **KEEP** — commit stays, log "fixed" |
+| `delta > 0` AND guard fails | **REWORK** — revert, try different approach (max 2 attempts) |
+| `delta == 0` | **DISCARD** — revert, fix didn't help |
+| `delta < 0` (more errors!) | **DISCARD** — revert immediately |
+| Crash during fix | **RECOVER** — revert, try simpler approach (max 3 attempts) |
+
+**Rework strategy (when guard fails):**
+1. Read the guard failure — understand what regressed
+2. Revert the failing fix: `git revert HEAD --no-edit`
+3. Understand why the fix broke something else (check cascading dependencies)
+4. Find an approach that fixes the target WITHOUT breaking the guard
+5. If 2 rework attempts fail → skip this item, add to `blocked.md`, move to next
+6. Log in fix-results.tsv with status "rework" and description of what was attempted
+
+**Decision matrix extended:**
+
+| Condition | delta | Guard | Action | TSV Status |
+|-----------|-------|-------|--------|-----------|
+| Perfect fix | > 0 | pass | KEEP | fixed |
+| Partial fix | > 0 | pass | KEEP + continue | fixed |
+| Regression introduced | > 0 | fail | REWORK | rework |
+| No effect | == 0 | - | DISCARD | discard |
+| Made it worse | < 0 | - | DISCARD immediately | discard |
+| Crash/exception | any | fail | RECOVER (simpler) | recover |
+| 3rd attempt fails | any | any | SKIP to blocked | blocked |
+
+## Phase 8: Log & Repeat
+
+**Append to fix-results.tsv:**
+```tsv
+iteration	category	target	delta	guard	status	description
+0	-	-	-	pass	baseline	47 test failures, 12 type errors, 3 lint errors
+1	type	auth.ts:42	-2	pass	fixed	add return type annotation
+2	type	db.ts:15	-1	pass	fixed	handle nullable column
+3	test	api.test.ts	-3	pass	fixed	fix expected status code (was 200, should be 201)
+4	test	auth.test.ts	0	-	discard	wrong approach — test expectation was correct
+5	test	auth.test.ts	-1	pass	fixed	missing await on async handler
+```
+
+**Every 5 iterations, print progress:**
+```
+=== Fix Progress (iteration 15) ===
+Baseline: 62 errors → Current: 23 errors (-39, -63%)
+Category breakdown:
+  Tests:  31/47 fixed
+  Types:  8/12 fixed
+  Lint:   0/3 fixed (not yet started — lower priority)
+Keeps: 11 | Discards: 3 | Reworks: 1
+```
+
+**Completion detection:**
+```
+IF current_errors == 0:
+  PRINT "=== All Clear — Zero Errors ==="
+  STOP (even in unbounded mode)
+```
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--target <command>` | Explicit verify command (overrides auto-detection) |
+| `--guard <command>` | Safety command that must always pass |
+| `--scope <glob>` | Limit fixes to specific files |
+| `--category <type>` | Only fix specific category (test, type, lint, build, bug) |
+| `--skip-lint` | Don't fix lint errors (focus on functional issues) |
+| `--from-debug` | Read findings from latest debug/ session |
+
+## Fix Session State Machine
+
+```
+States: DETECTING → PRIORITIZING → FIXING → VERIFYING → DECIDING → [DONE | LOOP]
+
+DETECTING:
+  → Run all error detection commands
+  → If zero errors found → DONE (nothing to fix)
+  → If errors found → PRIORITIZING
+
+PRIORITIZING:
+  → Sort errors by priority table
+  → Group cascading errors (fixing one fixes others)
+  → Pick first unfixed item → FIXING
+
+FIXING:
+  → Read error details + surrounding code
+  → Assess blast radius (impact assessment)
+  → Check git history for prior attempts on this file
+  → Apply minimal change
+  → Commit → VERIFYING
+
+VERIFYING:
+  → Re-run error detection
+  → Compute delta (previous - current)
+  → Run guard command → DECIDING
+
+DECIDING:
+  → delta > 0 AND guard passes → KEEP → log "fixed" → LOOP
+  → delta > 0 AND guard fails → REWORK (max 2) → FIXING
+  → delta == 0 → DISCARD → revert → PRIORITIZING (next item)
+  → delta < 0 → DISCARD → revert immediately → PRIORITIZING
+  → 3 failed attempts on same item → SKIP → blocked list → PRIORITIZING
+  → All items fixed or skipped → DONE
+
+DONE:
+  → Generate summary.md
+  → Print fix_score
+  → Suggest /autoresearch:debug for blocked items
+```
+
+## What NOT to Do — Anti-Patterns
+
+These shortcuts seem to fix the error but make things worse:
+
+| Anti-Pattern | Why It's Wrong | Do This Instead |
+|--------------|----------------|-----------------|
+| Add `@ts-ignore` / `eslint-disable` | Hides the problem — resurfaces as runtime error | Fix the root cause |
+| Use `any` type to silence TypeScript | Defeats type safety for the whole chain | Use proper types, generics, or `unknown` with narrowing |
+| Delete or skip failing tests | Removes the safety net | Fix the implementation to satisfy the test |
+| Suppress lint with inline comments | Accumulates tech debt silently | Apply the lint rule correctly |
+| `catch (e) {}` empty catch blocks | Swallows errors — bugs become invisible | Log at minimum; handle or re-throw |
+| Comment out broken code | It will never be uncommented | Fix it or delete it entirely |
+| Hardcode values to pass specific tests | Test passes, but feature is broken for real data | Fix the logic, not the values |
+| `--force` on npm/yarn install | Ignores peer dep conflicts causing runtime crashes | Resolve conflicts explicitly |
+| Increase test timeouts without fixing cause | Masks slow code or deadlocks | Profile and fix the underlying issue |
+
+**The ONE fix rule prevents most anti-patterns.** When tempted to use one, it signals the real fix is harder — log it, skip to next item, return with fresh context.
+
+## Fix Verification Depth
+
+Verification depth scales with blast radius:
+
+| Change Scope | Minimum Verification | Full Verification |
+|-------------|---------------------|-------------------|
+| Single utility function | Unit tests for that function | Unit + integration tests for callers |
+| Public API change | Integration tests | Unit + integration + contract tests |
+| Database schema | Migration dry-run | Staging environment smoke test |
+| Config / env var | CI pipeline run | Full deployment to staging |
+| Dependency upgrade | `npm test` | Full regression suite + e2e |
+| Auth / security code | Unit + integration | Security audit + penetration test |
+
+## Composite Metric
+
+For bounded loops, a nuanced fix_score accounting for quality of fixes:
+
+```
+fix_score = reduction_score + quality_score + bonus_score
+
+reduction_score = ((baseline_errors - current_errors) / baseline_errors) * 60
+  # Weight: 60% — primary goal is reducing errors
+
+quality_score = 0
+  # Deduct for low-quality fixes (anti-patterns used):
+  quality_score -= (suppression_count * 5)   # @ts-ignore, eslint-disable used
+  quality_score -= (skipped_test_count * 10)  # tests deleted/commented out
+  quality_score -= (any_type_count * 3)       # `any` type introduced
+  quality_score = max(quality_score, -20)     # floor: never below -20
+
+guard_score = (guard_always_passed ? 25 : 0)
+  # Weight: 25% — no regressions is critical
+
+bonus_score = 0
+  bonus_score += (zero_errors ? 10 : 0)              # all clear bonus
+  bonus_score += (no_discards ? 5 : 0)               # every fix worked first try
+  bonus_score += (compound_detected_and_fixed ? 5 : 0) # found hidden bugs too
+```
+
+**Interpretation:**
+- **100+** = perfect: all errors fixed, no regressions, no anti-patterns
+- **80-99** = good: significant progress, guards held, minimal anti-patterns
+- **60-79** = acceptable: meaningful reduction, but some regressions or anti-patterns
+- **<60** = needs work: too many discards, guard failures, or anti-patterns used
+
+## Fix Impact Assessment
+
+Before applying a fix, estimate the blast radius:
+
+```
+FUNCTION assessImpact(target_file, fix_type):
+  # How many files import this file?
+  dependents = grep -r "import.*{target_file}" src/
+
+  # Is this in a critical path?
+  is_critical = target_file in [auth, payments, database, api-gateway]
+
+  # How many tests cover this?
+  test_coverage = count tests that import or test target_file
+
+  RETURN {
+    dependents: N,
+    is_critical: bool,
+    test_coverage: N,
+    risk_level: HIGH if (dependents > 10 OR is_critical) else MEDIUM if dependents > 3 else LOW
+  }
+```
+
+| Risk Level | Action |
+|------------|--------|
+| LOW | Fix and verify with unit tests |
+| MEDIUM | Fix with unit + integration tests as guard |
+| HIGH | Fix in isolation branch, verify against full suite, get review before merge |
+
+## Compound Fix Detection
+
+When fixing one error reveals another, or a fix is only partial:
+
+```
+FUNCTION detectCompound(before_errors, after_errors):
+  new_errors = after_errors - before_errors  # errors that didn't exist before
+
+  IF new_errors > 0:
+    LOG "Compound fix detected: {N} new errors surfaced"
+    # These are likely pre-existing errors that were masked
+    ADD new_errors to fix queue at current priority
+    CONTINUE (do not treat as regression)
+
+  IF delta == 0 AND error_details_changed:
+    LOG "Error transformed — not fixed, just moved"
+    REVERT and try different approach
+```
+
+**Common compound patterns:**
+- Fixing a type error reveals a logic error that the wrong type was hiding
+- Fixing a null check reveals a missing initialization
+- Upgrading a dependency reveals previously passing tests were relying on a bug
+- Fixing test A reveals test B was sharing mutable state
+
+## Rollback Protocol
+
+When a fix makes things worse (delta < 0) or breaks the guard:
+
+```
+STEP 1: Identify the bad commit
+  git log --oneline -5
+
+STEP 2: Revert the specific commit
+  git revert HEAD --no-edit
+  # OR for harder cases:
+  git reset --soft HEAD~1  # unstage the commit
+  git checkout -- .        # discard working changes
+
+STEP 3: Verify rollback succeeded
+  Run original failing command — should return to pre-fix error count
+
+STEP 4: Log the failed approach in fix-results.tsv
+  Mark as "discard" with description of why it failed
+
+STEP 5: Analyze before retrying
+  - What assumption was wrong?
+  - What did the fix break?
+  - Is there a smaller, safer change?
+```
+
+**Never skip rollback.** A partial fix in a broken state makes the next iteration's error detection unreliable.
+
+## Parallel Fix Detection
+
+Some errors are independent and can be fixed in parallel (separate files, no shared state):
+
+```
+FUNCTION detectParallelizable(error_list):
+  groups = {}
+
+  FOR each error:
+    affected_files = error.file
+    FOR each group:
+      IF affected_files overlaps group.files:
+        MERGE error into group  # dependent
+      ELSE:
+        CREATE new group        # independent
+
+  independent_groups = groups where len(group.files) == 1
+
+  RETURN independent_groups  # can be fixed in parallel subagents
+```
+
+**When to parallelize:** 5+ independent errors across different modules. Spawn parallel fix agents with `--scope` to isolate.
+
+## Fix History Pattern Learning
+
+Before attempting a fix, check git history for past approaches on the same file:
+
+```bash
+# See what fixes were tried in this file before
+git log --oneline --follow -- src/auth/handler.ts
+
+# See the diff of a specific past fix
+git show <commit-hash> -- src/auth/handler.ts
+
+# Search for past fix attempts on this error type
+git log --grep="fix: type error" --oneline
+```
+
+**Pattern signals:**
+- Same error fixed 3+ times → root cause not addressed, fix the architectural issue
+- Recent revert in same file → previous approach failed, avoid repeating it
+- Large diff for "simple" fix → complexity hidden in that file, be careful with changes
+
+## The Fix Didn't Work — Escalation Path
+
+When 3 attempts at the same error fail:
+
+```
+Attempt 1: FAIL → Log approach, try different strategy
+Attempt 2: FAIL → Log approach, read git history for prior attempts
+Attempt 3: FAIL → Escalate:
+
+  1. DOCUMENT: What was tried (3 approaches), why each failed
+  2. ISOLATE: Create minimal reproduction case
+  3. SKIP: Move this error to "blocked" list, continue with others
+  4. FLAG: Note in summary.md — "Error X requires investigation"
+  5. SUGGEST: /autoresearch:debug on the specific error for root cause analysis
+```
+
+**Never loop on the same failing approach.** Each attempt must use a materially different strategy.
+
+## Dependency Fix Patterns
+
+When the error originates from `node_modules`, `pip` packages, or vendored dependencies:
+
+| Symptom | Strategy | Command |
+|---------|----------|---------|
+| Peer dependency conflict | Upgrade to compatible version | `npm install pkg@latest` |
+| Breaking change in minor update | Pin to last working version | `npm install pkg@1.2.3` |
+| Security vulnerability | Patch or replace | `npm audit fix` / replace with alternative |
+| Transitive dependency conflict | Force resolution | `package.json` resolutions/overrides field |
+| Python package incompatibility | Pin in requirements | `pip install pkg==x.y.z` |
+| Missing native bindings | Rebuild from source | `npm rebuild` / `pip install --no-binary` |
+
+**Rule:** Never vendor-patch `node_modules` directly — it will be overwritten. Add a `patch-package` patch or fork.
+
+## Database Migration Fix Patterns
+
+When errors involve schema conflicts or data integrity:
+
+| Error Type | Strategy |
+|------------|----------|
+| Migration out of order | Check migration history table, apply missing migrations in sequence |
+| Schema conflict (column exists) | Make migration idempotent: `IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` |
+| Data integrity violation | Fix data BEFORE applying constraint, or migrate in two steps: add nullable → backfill → add constraint |
+| Failed rollback | Restore from backup, replay forward migrations to known-good point |
+| Enum type conflict (Postgres) | Cannot alter enums in transactions — use `ALTER TYPE` outside transaction block |
+
+**Rule:** Always test migrations on a copy of production data before applying. Use `--dry-run` if available.
+
+## CI/CD Pipeline Fix Patterns
+
+When errors appear only in CI (not locally):
+
+| Symptom | Root Cause | Fix |
+|---------|------------|-----|
+| `env var not found` | Secret not in CI environment | Add secret to CI settings, reference via `${{ secrets.NAME }}` |
+| Permission denied | Missing IAM role / workflow permissions | Add `permissions:` block to workflow YAML |
+| Timeout | Slow test / missing cache | Add caching step, increase timeout, parallelize jobs |
+| Works locally, fails in CI | OS difference (macOS vs Linux) | Test in Docker matching CI OS; check path case sensitivity |
+| Flaky test in CI | Race condition or timing | Add retry logic, fix async handling, isolate test state |
+| Cache poisoning | Stale cache from broken state | Clear CI cache, add cache key version bump |
+
+## Auto-Detection Reference
+
+| Signal | Detected Type | Verify Command |
+|--------|---------------|----------------|
+| `package.json` has `test` script | test | `npm test` |
+| `tsconfig.json` exists | type | `tsc --noEmit` |
+| `.eslintrc*` or `eslint.config.*` exists | lint | `npx eslint .` |
+| `pyproject.toml` has `pytest` | test | `pytest` |
+| `pyproject.toml` has `mypy` or `ruff` | type + lint | `mypy .`, `ruff check .` |
+| `Cargo.toml` exists | test + lint | `cargo test`, `cargo clippy` |
+| `go.mod` exists | test + lint | `go test ./...`, `golangci-lint run` |
+| `build` script in package.json | build | `npm run build` |
+| `next.config.*` exists | build | `next build` |
+| `vite.config.*` exists | build | `vite build` |
+| `.github/workflows/*.yml` exists | ci | Check latest run: `gh run list --limit 1` |
+| `debug/*/findings.md` exists | bug | Parse findings |
+| `tsc --noEmit` shows `TS2322`, `TS2345` | type error | Fix type mismatch |
+| test output shows `Expected.*Received` | test failure | Fix assertion |
+| build log shows `Module not found` | build failure | Fix import path |
+| CI log shows `exit code 1` | ci | Inspect failed step |
+
+## Chaining Patterns
+
+```bash
+# Debug first, then fix what was found
+/loop 15 /autoresearch:debug
+/loop 30 /autoresearch:fix --from-debug
+
+# Fix with guard
+/autoresearch:fix
+Target: npm run typecheck
+Guard: npm test
+
+# Fix only tests, guard with types
+/autoresearch:fix --category test --guard "tsc --noEmit"
+
+# Fix everything — iterate until clean
+/autoresearch:fix
+
+# Bounded sprint — fix as many as you can in 20 iterations
+/loop 20 /autoresearch:fix
+```
+
+## Output Directory
+
+Creates `fix/{YYMMDD}-{HHMM}-{fix-slug}/` with:
+- `fix-results.tsv` — iteration log
+- `summary.md` — what was fixed, what remains, stats
+- `blocked.md` — errors that needed 3+ attempts and were escalated
+- `impact-assessment.md` — blast radius analysis for each fix applied
+
+## Extended Chaining Patterns
+
+```bash
+# Full pipeline: debug → fix → ship
+/loop 15 /autoresearch:debug
+/loop 30 /autoresearch:fix --from-debug --guard "npm test"
+/autoresearch:ship
+
+# Fix only critical issues, then verify clean
+/autoresearch:fix --category build
+/autoresearch:fix --category type --guard "npm run build"
+/autoresearch:fix --category test --guard "tsc --noEmit"
+
+# Scoped fix with parallel agents
+/autoresearch:fix --scope "src/api/**" --category type
+/autoresearch:fix --scope "src/auth/**" --category test
+
+# Fix with warning suppression disabled
+/autoresearch:fix --category warning --skip-lint
+
+# CI-specific fix: re-run on CI failure
+/autoresearch:fix --target "npm run ci" --guard "npm test"
+
+# After dependency upgrade: fix cascade
+npm upgrade && /autoresearch:fix --category type --category test
+```
+
+## Summary Report Format
+
+```markdown
+# Fix Session Summary
+
+## Stats
+- Session: fix/260316-1805-auth-fixes/
+- Duration: 23 iterations
+- Baseline: 47 errors (31 test, 12 type, 4 lint)
+- Final: 3 errors (2 test, 1 type, 0 lint)
+- Reduction: 93.6% (-44 errors)
+
+## Fix Score
+fix_score: 97/100
+- Reduction: 58/60 (93.6%)
+- Guard: 25/25 (no regressions)
+- Bonus: +10 (zero lint errors)
+- Anti-patterns used: 0
+
+## Fixed
+- auth.ts:42 — add return type annotation (type)
+- db.ts:15 — handle nullable column (type)
+- api.test.ts — fix expected status code 200→201 (test)
+[... 41 more ...]
+
+## Blocked (requires investigation)
+- auth/token-refresh.ts — circular dependency blocks type resolution
+  → Suggested: /autoresearch:debug --scope auth/token-refresh.ts
+
+## Remaining
+- user.test.ts:88 — flaky timing test (not a code bug)
+- config.ts:12 — type error requires breaking API change
+```


### PR DESCRIPTION
## Summary

Adds two new subcommands that apply the autoresearch loop pattern to debugging and fixing — making them **autonomous, iterative, and metric-driven**. Unlike single-pass debug/fix tools, these loop until the codebase is clean.

## What's New

### `/autoresearch:debug` — Autonomous Bug Hunter

Scientific method meets autoresearch loop. Doesn't stop at one bug — iteratively hunts ALL bugs.

**7-phase loop:** Gather → Recon → Hypothesize → Test → Classify → Log → Repeat

| Feature | Detail |
|---------|--------|
| Investigation techniques | Binary search, differential, minimal reproduction, trace, pattern search, working backwards, rubber duck |
| Cognitive bias guards | Confirmation, anchoring, sunk cost, availability |
| Language bug patterns | JS, TS, Python, Go, Rust, Java, SQL — 15 common patterns |
| Domain debugging | API, database, auth, async/concurrency, network — dedicated checklists |
| Root cause analysis | The 5 Whys drill-down technique |
| Evidence standard | Every finding needs file:line + reproduction steps + code evidence |
| Auto-chain | `--fix` flag switches to /autoresearch:fix after hunting |

```bash
/loop 20 /autoresearch:debug
Scope: src/api/**/*.ts
Symptom: API returns 500 on POST /users
```

### `/autoresearch:fix` — Autonomous Error Crusher

Takes a broken state and iteratively repairs it until zero errors remain.

**8-phase loop:** Detect → Prioritize → Fix ONE → Commit → Verify → Guard → Decide → Repeat

| Feature | Detail |
|---------|--------|
| Auto-detection | Tests, types, lint, build, CI — auto-detected from project |
| Priority queue | Blockers → errors → warnings (never polish while broken) |
| Atomic fixes | ONE fix per iteration, auto-reverted on regression |
| Guard integration | Every fix must pass the guard (no regressions) |
| Language strategies | TypeScript, Python, Go, Rust, Java — never-do/correct-pattern tables |
| Anti-patterns | 9-row table: never suppress, never delete tests, never use `any` |
| Compound detection | Fixing one error reveals another — handled gracefully |
| Impact assessment | Blast radius analysis before each fix |
| Rollback protocol | 5-step structured rollback when fixes make things worse |
| Escalation | After 3 failed attempts → document, isolate, skip, flag |
| Domain patterns | Dependencies, DB migrations, CI/CD pipelines |
| Auto-stop | Stops at zero errors even in unbounded mode |

```bash
/autoresearch:fix
# Or chain: debug then fix
/autoresearch:debug --fix
```

## How It Was Built

Both protocols were **refined through 35 autoresearch loop iterations** across 3 parallel agents:

```
Score: 90/100 → 143/150 (rubric expanded mid-loop)
Iterations: 35 total (13 debug + 19 fix + 2 manual + 1 scoring)
Protocol size: 490 → 1,092 lines (+123%)
```

The autoresearch loop was used to improve its own debugging/fixing protocols — meta-improvement.

## Files Changed (14 files, +2,501 lines)

| File | Change |
|------|--------|
| `skills/autoresearch/references/debug-workflow.md` | New — 442 lines, full debug protocol |
| `skills/autoresearch/references/fix-workflow.md` | New — 650 lines, full fix protocol |
| `commands/autoresearch/debug.md` | New — command registration |
| `commands/autoresearch/fix.md` | New — command registration |
| `.claude/skills/autoresearch/references/debug-workflow.md` | Copy for local use |
| `.claude/skills/autoresearch/references/fix-workflow.md` | Copy for local use |
| `.claude/commands/autoresearch/debug.md` | Copy for local use |
| `.claude/commands/autoresearch/fix.md` | Copy for local use |
| `skills/autoresearch/SKILL.md` | Subcommands table + activation triggers + version 1.3.0 |
| `.claude/skills/autoresearch/SKILL.md` | Synced copy |
| `README.md` | Commands table, quick guide, new sections, version badge |
| `EXAMPLES.md` | Debug/fix examples with session outputs |
| `.claude-plugin/marketplace.json` | Version + description update |
| `.claude-plugin/plugin.json` | Version + description update |

## Test plan

- [ ] Run `/autoresearch:debug` — should load debug workflow protocol
- [ ] Run `/autoresearch:fix` — should load fix workflow protocol
- [ ] Run `/autoresearch:debug --fix` — should chain debug then fix
- [ ] Run `/autoresearch:fix --from-debug` — should read latest debug findings
- [ ] Run `/autoresearch:fix --category test` — should fix only test failures
- [ ] Verify `--guard` flag works (fix without regressions)
- [ ] Verify auto-stop at zero errors in unbounded mode