### PR TITLE
feat: interactive AskUserQuestion setup for all commands (v1.3.1)

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.3.0
+version: 1.3.1
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.3.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 [![Follow @iuditg](https://img.shields.io/badge/Follow-@iuditg-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/follow?screen_name=iuditg)
@@ -87,6 +87,8 @@ Before looping, Claude performs a one-time setup:
 | `/autoresearch:debug` | Autonomous bug-hunting loop — scientific method + iterative investigation |
 | `/autoresearch:fix` | Autonomous fix loop — iteratively repair errors until zero remain |
 | `Guard: <command>` | Optional safety net — must pass for changes to be kept |
+
+**All commands use `AskUserQuestion` for interactive setup when invoked without arguments.** Just type the command — Claude will ask you what you need step by step with smart defaults based on your codebase. Power users can skip the wizard by providing flags inline.
 
 ### Quick Decision Guide
 

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.3.0
+version: 1.3.1
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration


### PR DESCRIPTION
## Summary

All 6 autoresearch subcommands now use Claude's `AskUserQuestion` tool for guided interactive setup when invoked without arguments. No more guessing what to type — Claude asks step-by-step with smart defaults based on your codebase.

## What Changed

### Before (v1.3.0)
Users had to know the exact syntax:
```
/autoresearch
Goal: Increase test coverage from 72% to 90%
Scope: src/**/*.test.ts, src/**/*.ts
Metric: coverage % (higher is better)
Verify: npm test -- --coverage | grep "All files"
```

### After (v1.3.1)
Just type the command — Claude walks you through it:
```
/autoresearch
→ "What do you want to improve?" [options based on detected tooling]
→ "Which files can autoresearch modify?" [suggested globs]
→ "What number tells you if things got better?" [detected metrics]
→ "What command produces the metric?" [dry-run validated]
→ "Any guard command?" [optional]
→ "Config looks good?" [Launch / Edit / Cancel]
```

Power users can still provide everything inline — interactive setup is skipped when flags are present.

### Interactive Setup per Command

| Command | Questions | Skips When |
|---------|-----------|------------|
| `/autoresearch` | Goal, Scope, Metric, Verify, Guard (5) | Inline config provided |
| `/autoresearch:plan` | Already had AskUserQuestion | Goal provided inline |
| `/autoresearch:security` | Scope, Depth, After-action (3) | `--diff`, `--fix`, `--fail-on` flags |
| `/autoresearch:ship` | Ship type, Ship mode (2) | `--type`, `--dry-run`, `--auto` flags |
| `/autoresearch:debug` | Symptom, Scope, After-action (3) | `--scope`, `--symptom`, `--fix` flags |
| `/autoresearch:fix` | Category, Guard, Scope, Confirm (4) | `--target`, `--guard`, `--scope` flags |

### Smart Defaults

Each question provides options based on codebase scanning:
- **Scope:** Suggests globs from project structure (`src/**/*.ts`, `content/**/*.md`)
- **Metric:** Detects tooling (Jest → coverage %, TypeScript → error count, ESLint → violations)
- **Verify:** Constructs command from detected tools, dry-runs to validate
- **Guard:** Suggests `npm test`, `tsc --noEmit` based on what's available

## Files Changed

| File | Change |
|------|--------|
| `skills/autoresearch/SKILL.md` | Interactive setup phase + version 1.3.1 |
| `.claude/skills/autoresearch/SKILL.md` | Synced |
| `skills/autoresearch/references/debug-workflow.md` | 3-question interactive setup |
| `skills/autoresearch/references/fix-workflow.md` | 4-question interactive setup |
| `skills/autoresearch/references/security-workflow.md` | 3-question interactive setup |
| `skills/autoresearch/references/ship-workflow.md` | 2-question interactive setup |
| `README.md` | Version badge + interactive setup note in Commands section |

## Test plan

- [ ] Run `/autoresearch` without args — should trigger AskUserQuestion wizard
- [ ] Run `/autoresearch:debug` without args — should ask symptom, scope, after-action
- [ ] Run `/autoresearch:fix` without args — should ask category, guard, scope
- [ ] Run `/autoresearch:security` without args — should ask scope, depth, after-action
- [ ] Run `/autoresearch:ship` without args — should ask type, mode
- [ ] Run `/autoresearch:fix --target "npm test" --guard "tsc"` — should skip wizard
- [ ] Verify all 6 commands still work with inline flags (no regression)