### PR TITLE
feat: batched AskUserQuestion setup for all commands (v1.3.2)

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.3.1
+version: 1.3.2
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.3.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.3.2-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 [![Follow @iuditg](https://img.shields.io/badge/Follow-@iuditg-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/follow?screen_name=iuditg)

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.3.1
+version: 1.3.2
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration


### PR DESCRIPTION
## Summary

- **Version bump to 1.3.2** across SKILL.md (both locations) and README badge
- Follows up on PR #20 which introduced batched `AskUserQuestion` calls for all 6 subcommands

### What changed in v1.3.2

All interactive setup flows now batch 3-4 questions per `AskUserQuestion` call instead of asking one at a time:

| Subcommand | Questions per call | Topics |
|------------|-------------------|--------|
| `/autoresearch` | Batch 1: 4 (Goal, Scope, Metric, Direction) + Batch 2: 3 (Verify, Guard, Launch) |
| `/autoresearch:debug` | 1 call: 4 (Issue, Scope, Depth, After) |
| `/autoresearch:fix` | 1 call: 4 (Fix What, Guard, Scope, Launch) |
| `/autoresearch:security` | 1 call: 3 (Scope, Depth, Action) |
| `/autoresearch:ship` | 1 call: 3 (What, Mode, Monitor) |
| `/autoresearch:plan` | Batch 1: 4 (Goal, Scope, Metric, Direction) + Batch 2: 3 (Verify, Guard, Launch) |

### Why

Users reported that asking one question at a time was tedious. Batching gives users full context upfront and reduces round-trips.

## Test plan

- [x] Version badges updated in README
- [x] SKILL.md version updated in both `skills/` and `.claude/skills/`
- [x] All batched question definitions verified in reference files