### PR TITLE
fix: register base /autoresearch command (v1.3.3)

### DIFF
--- a/.claude/commands/autoresearch.md
+++ b/.claude/commands/autoresearch.md
@@ -1,0 +1,18 @@
+---
+name: autoresearch
+description: Autonomous Goal-directed Iteration. Modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
+argument-hint: "[Goal: <text>] [Scope: <glob>] [Metric: <text>] [Verify: <cmd>]"
+---
+
+Load and follow the autoresearch autonomous loop protocol.
+
+1. Read the skill file: `.claude/skills/autoresearch/SKILL.md` — understand the full framework, setup phase, and critical rules
+2. Read the core principles: `.claude/skills/autoresearch/references/core-principles.md`
+3. Read the autonomous loop protocol: `.claude/skills/autoresearch/references/autonomous-loop-protocol.md`
+4. Read the results logging format: `.claude/skills/autoresearch/references/results-logging.md`
+5. Parse any inline config from the user's arguments: $ARGUMENTS
+6. If Goal, Scope, Metric, and Verify are all provided — extract them and proceed to setup step 5
+7. If any critical field is missing — run the interactive setup with batched `AskUserQuestion` calls as defined in SKILL.md
+8. Execute the autonomous loop: Modify → Verify → Keep/Discard → Repeat
+
+Follow the protocol exactly. One atomic change per iteration. Mechanical verification only. Auto-rollback on failure.

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.3.2
+version: 1.3.3
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.3.2-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.3.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 [![Follow @iuditg](https://img.shields.io/badge/Follow-@iuditg-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/follow?screen_name=iuditg)

--- a/commands/autoresearch.md
+++ b/commands/autoresearch.md
@@ -1,0 +1,18 @@
+---
+name: autoresearch
+description: Autonomous Goal-directed Iteration. Modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
+argument-hint: "[Goal: <text>] [Scope: <glob>] [Metric: <text>] [Verify: <cmd>]"
+---
+
+Load and follow the autoresearch autonomous loop protocol.
+
+1. Read the skill file: `skills/autoresearch/SKILL.md` — understand the full framework, setup phase, and critical rules
+2. Read the core principles: `skills/autoresearch/references/core-principles.md`
+3. Read the autonomous loop protocol: `skills/autoresearch/references/autonomous-loop-protocol.md`
+4. Read the results logging format: `skills/autoresearch/references/results-logging.md`
+5. Parse any inline config from the user's arguments: $ARGUMENTS
+6. If Goal, Scope, Metric, and Verify are all provided — extract them and proceed to setup step 5
+7. If any critical field is missing — run the interactive setup with batched `AskUserQuestion` calls as defined in SKILL.md
+8. Execute the autonomous loop: Modify → Verify → Keep/Discard → Repeat
+
+Follow the protocol exactly. One atomic change per iteration. Mechanical verification only. Auto-rollback on failure.

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.3.2
+version: 1.3.3
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration


### PR DESCRIPTION
## Summary

Fixes #22 — `/autoresearch` (without suffix) throws "Unknown skill: autoresearch" error.

### Root Cause

Claude Code resolves slash commands via `.claude/commands/<name>.md` files. The subcommands (`:debug`, `:fix`, `:plan`, `:security`, `:ship`) each had their registration file in `commands/autoresearch/<subcommand>.md`, but the **base `/autoresearch` command itself** was missing its `commands/autoresearch.md` file — only the `commands/autoresearch/` directory existed.

This is the same class of bug as #14 (which fixed the subcommand registrations).

### Fix

Created `commands/autoresearch.md` (and `.claude/commands/autoresearch.md`) with:
- Proper frontmatter (`name`, `description`, `argument-hint`)
- Instructions to load SKILL.md, core principles, autonomous loop protocol, and results logging
- Inline config parsing + interactive setup fallback
- Version bump to 1.3.3

### Files Changed

| File | Change |
|------|--------|
| `commands/autoresearch.md` | **NEW** — base command registration (distributable) |
| `.claude/commands/autoresearch.md` | **NEW** — base command registration (local) |
| `skills/autoresearch/SKILL.md` | Version 1.3.2 → 1.3.3 |
| `.claude/skills/autoresearch/SKILL.md` | Version 1.3.2 → 1.3.3 |
| `README.md` | Version badge 1.3.2 → 1.3.3 |

## Test plan

- [x] `/autoresearch` now appears in skills catalog (verified locally)
- [x] Subcommands (`:debug`, `:fix`, etc.) still registered and working
- [x] Version bumped consistently across all files