### PR TITLE
fix: replace /loop N with native Iterations: N config (v1.4.0)

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.3.3
+description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+version: 1.4.0
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
@@ -59,7 +59,8 @@ Load: `references/security-workflow.md` for full protocol.
 /autoresearch:security
 
 # Bounded — exactly 10 security sweep iterations
-/loop 10 /autoresearch:security
+/autoresearch:security
+Iterations: 10
 
 # With focused scope
 /autoresearch:security
@@ -70,13 +71,16 @@ Focus: authentication and authorization flows
 /autoresearch:security --diff
 
 # Auto-fix confirmed Critical/High findings after audit
-/loop 15 /autoresearch:security --fix
+/autoresearch:security --fix
+Iterations: 15
 
 # CI/CD gate — fail pipeline if any Critical findings
-/loop 10 /autoresearch:security --fail-on critical
+/autoresearch:security --fail-on critical
+Iterations: 10
 
 # Combined — delta audit + fix + gate
-/loop 15 /autoresearch:security --diff --fix --fail-on critical
+/autoresearch:security --diff --fix --fail-on critical
+Iterations: 15
 ```
 
 **Inspired by:**
@@ -143,7 +147,8 @@ Load: `references/ship-workflow.md` for full protocol.
 /autoresearch:ship --monitor 10
 
 # Prepare iteratively then ship
-/loop 5 /autoresearch:ship
+/autoresearch:ship
+Iterations: 5
 
 # Just check if something is ready to ship
 /autoresearch:ship --checklist-only
@@ -220,13 +225,9 @@ After the wizard completes, the user gets a ready-to-paste `/autoresearch` invoc
 - User says "work autonomously", "iterate until done", "keep improving", "run overnight" → run the loop
 - Any task requiring repeated iteration cycles with measurable outcomes → run the loop
 
-## Optional: Controlled Loop Count
+## Bounded Iterations
 
-By default, autoresearch loops **forever** until manually interrupted. However, users can optionally specify a **loop count** to limit iterations using Claude Code's built-in `/loop` command.
-
-> **Requires:** Claude Code v1.0.32+ (the `/loop` command was introduced in this version)
-
-### Usage
+By default, autoresearch loops **forever** until manually interrupted. To run exactly N iterations, add `Iterations: N` to your inline config.
 
 **Unlimited (default):**
 ```
@@ -236,29 +237,22 @@ Goal: Increase test coverage to 90%
 
 **Bounded (N iterations):**
 ```
-/loop 25 /autoresearch
+/autoresearch
 Goal: Increase test coverage to 90%
+Iterations: 25
 ```
 
-This chains `/autoresearch` with `/loop 25`, running exactly 25 iteration cycles. After 25 iterations, Claude stops and prints a final summary.
+After N iterations Claude stops and prints a final summary with baseline → current best, keeps/discards/crashes. If the goal is achieved before N iterations, Claude prints early completion and stops.
 
-### When to Use Bounded Loops
+### When to Use Bounded Iterations
 
 | Scenario | Recommendation |
 |----------|---------------|
 | Run overnight, review in morning | Unlimited (default) |
-| Quick 30-min improvement session | `/loop 10 /autoresearch` |
-| Targeted fix with known scope | `/loop 5 /autoresearch` |
-| Exploratory — see if approach works | `/loop 15 /autoresearch` |
-| CI/CD pipeline integration | `/loop N /autoresearch` (set N based on time budget) |
-
-### Behavior with Loop Count
-
-When a loop count is specified:
-- Claude runs exactly N iterations through the autoresearch loop
-- After iteration N, Claude prints a **final summary** with baseline → current best, keeps/discards/crashes
-- If the goal is achieved before N iterations, Claude prints early completion and stops
-- All other rules (atomic changes, mechanical verification, auto-rollback) still apply
+| Quick 30-min improvement session | `Iterations: 10` |
+| Targeted fix with known scope | `Iterations: 5` |
+| Exploratory — see if approach works | `Iterations: 15` |
+| CI/CD pipeline integration | `--iterations N` flag (set N based on time budget) |
 
 ## Setup Phase (Do Once)
 
@@ -287,7 +281,7 @@ Use a SINGLE `AskUserQuestion` call with these 4 questions:
 |---|--------|----------|---------|
 | 5 | `Verify` | "What command produces the metric? (I'll dry-run it to confirm)" | Suggested commands from detected tooling |
 | 6 | `Guard` | "Any command that must ALWAYS pass? (prevents regressions)" | "npm test", "tsc --noEmit", "npm run build", "Skip — no guard" |
-| 7 | `Launch` | "Ready to go?" | "Launch (unlimited)", "Launch with /loop N", "Edit config", "Cancel" |
+| 7 | `Launch` | "Ready to go?" | "Launch (unlimited)", "Launch with iteration limit", "Edit config", "Cancel" |
 
 **After Batch 2:** Dry-run the verify command. If it fails, ask user to fix or choose a different command. If it passes, proceed with launch choice.
 

--- a/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -7,7 +7,7 @@ Detailed protocol for the autoresearch iteration loop. SKILL.md has the summary;
 Autoresearch supports two loop modes:
 
 - **Unbounded (default):** Loop forever until manually interrupted (`Ctrl+C`)
-- **Bounded:** Loop exactly N times when chained with `/loop N` (requires Claude Code v1.0.32+)
+- **Bounded:** Loop exactly N times when `Iterations: N` is set in the inline config (or `--iterations N` flag for CLI/CI)
 
 When bounded, track `current_iteration` against `max_iterations`. After the final iteration, print a summary and stop.
 
@@ -152,7 +152,7 @@ iteration  commit   metric   status   description
 
 Go to Phase 1. **NEVER STOP. NEVER ASK IF YOU SHOULD CONTINUE.**
 
-### Bounded Mode (with /loop N)
+### Bounded Mode (with Iterations: N)
 
 ```
 IF current_iteration < max_iterations:

--- a/.claude/skills/autoresearch/references/debug-workflow.md
+++ b/.claude/skills/autoresearch/references/debug-workflow.md
@@ -17,7 +17,8 @@ Autonomous bug-hunting loop that applies the scientific method iteratively. Does
 /autoresearch:debug
 
 # Bounded — exactly N investigation iterations
-/loop 20 /autoresearch:debug
+/autoresearch:debug
+Iterations: 20
 
 # Focused scope
 /autoresearch:debug
@@ -454,8 +455,11 @@ Creates `debug/{YYMMDD}-{HHMM}-{debug-slug}/` with:
 /autoresearch:debug --fix
 
 # Or manually chain
-/loop 15 /autoresearch:debug    # hunt bugs
-/loop 20 /autoresearch:fix      # fix everything found
+/autoresearch:debug
+Iterations: 15
+
+/autoresearch:fix
+Iterations: 20
 ```
 
 When `--fix` is specified, after the debug loop completes, automatically switches to `/autoresearch:fix` targeting the discovered issues.

--- a/.claude/skills/autoresearch/references/fix-workflow.md
+++ b/.claude/skills/autoresearch/references/fix-workflow.md
@@ -17,7 +17,8 @@ Autonomous fix loop that takes a broken state and iteratively repairs it until e
 /autoresearch:fix
 
 # Bounded — exactly N fix iterations
-/loop 30 /autoresearch:fix
+/autoresearch:fix
+Iterations: 30
 
 # With explicit target
 /autoresearch:fix
@@ -41,7 +42,7 @@ Use ONE `AskUserQuestion` call with all 4 questions:
 | 1 | `Fix What` | "Found [N] test failures, [M] type errors, [K] lint errors. What should I fix?" | "Fix everything (recommended)", "Only tests", "Only type errors", "Only lint" |
 | 2 | `Guard` | "What command must ALWAYS pass? (prevents fixes from breaking other things)" | "npm test", "tsc --noEmit", "npm run build", "Skip — no guard" |
 | 3 | `Scope` | "Which files can I modify?" | Suggested globs from error locations + "All project files" |
-| 4 | `Launch` | "Ready to fix?" | "Fix until zero errors", "Fix with /loop N", "Edit config", "Cancel" |
+| 4 | `Launch` | "Ready to fix?" | "Fix until zero errors", "Fix with iteration limit", "Edit config", "Cancel" |
 
 **IMPORTANT:** Always ask all 4 questions in a single call — never one at a time. Users need the full picture (what's broken, what's the guard, what's the scope) to make informed decisions together.
 
@@ -583,8 +584,11 @@ When errors appear only in CI (not locally):
 
 ```bash
 # Debug first, then fix what was found
-/loop 15 /autoresearch:debug
-/loop 30 /autoresearch:fix --from-debug
+/autoresearch:debug
+Iterations: 15
+
+/autoresearch:fix --from-debug
+Iterations: 30
 
 # Fix with guard
 /autoresearch:fix
@@ -598,7 +602,8 @@ Guard: npm test
 /autoresearch:fix
 
 # Bounded sprint — fix as many as you can in 20 iterations
-/loop 20 /autoresearch:fix
+/autoresearch:fix
+Iterations: 20
 ```
 
 ## Output Directory
@@ -613,8 +618,12 @@ Creates `fix/{YYMMDD}-{HHMM}-{fix-slug}/` with:
 
 ```bash
 # Full pipeline: debug → fix → ship
-/loop 15 /autoresearch:debug
-/loop 30 /autoresearch:fix --from-debug --guard "npm test"
+/autoresearch:debug
+Iterations: 15
+
+/autoresearch:fix --from-debug --guard "npm test"
+Iterations: 30
+
 /autoresearch:ship
 
 # Fix only critical issues, then verify clean

--- a/.claude/skills/autoresearch/references/plan-workflow.md
+++ b/.claude/skills/autoresearch/references/plan-workflow.md
@@ -213,7 +213,7 @@ AskUserQuestion:
 ```
 
 If "Launch now — unlimited": invoke `/autoresearch` with the configuration.
-If "Launch now — bounded": ask for iteration count, then invoke `/loop N /autoresearch`.
+If "Launch now — bounded": ask for iteration count, then invoke `/autoresearch` with `Iterations: N` in the inline config.
 If "Copy config only": output the ready-to-paste command block and stop.
 
 ## Metric Suggestion Database

--- a/.claude/skills/autoresearch/references/security-workflow.md
+++ b/.claude/skills/autoresearch/references/security-workflow.md
@@ -19,7 +19,8 @@ Works with both unbounded and bounded modes:
 /autoresearch:security
 
 # Bounded — run exactly N security sweep iterations
-/loop 10 /autoresearch:security
+/autoresearch:security
+Iterations: 10
 
 # With target scope
 /autoresearch:security
@@ -263,7 +264,7 @@ iteration	vector	severity	owasp	stride	confidence	location	description
 #### Phase 6: Repeat
 
 - **Unbounded:** Keep finding vulnerabilities. Never stop. Never ask.
-- **Bounded (/loop N):** After N iterations, generate final report and stop.
+- **Bounded (Iterations: N):** After N iterations, generate final report and stop.
 - **Coverage tracking:** Every 5 iterations, print coverage summary.
 
 ### Coverage Summary Format
@@ -475,7 +476,7 @@ Never report a finding without proof. For each vulnerability:
 4. Show the impact (data leaked, access gained, etc.)
 
 ### Multi-Agent Attack Collaboration
-When using `/loop`, each iteration should build on prior findings:
+Each iteration should build on prior findings:
 - Iteration 1 finds open endpoint → Iteration 2 chains with IDOR
 - Iteration 3 finds missing rate limit → Iteration 4 tests brute force feasibility
 - Findings compound. Each iteration reads past findings for chaining opportunities.
@@ -580,7 +581,7 @@ Exit with non-zero code if findings meet or exceed a severity threshold. Designe
 **CI/CD usage:**
 ```bash
 # In GitHub Actions or CI scripts
-/loop 10 /autoresearch:security --fail-on critical
+claude -p "/autoresearch:security --fail-on critical --iterations 10"
 # Exit code 1 if any Critical findings → blocks the pipeline
 ```
 
@@ -590,7 +591,9 @@ After completing the audit, switches to standard autoresearch modify→verify lo
 
 ```
 /autoresearch:security --fix
-/loop 10 /autoresearch:security --fix
+
+/autoresearch:security --fix
+Iterations: 10
 ```
 
 **How it works:**
@@ -631,10 +634,12 @@ Flags can be combined:
 
 ```
 # Delta audit + auto-fix critical/high + block on remaining criticals
-/loop 15 /autoresearch:security --diff --fix --fail-on critical
+/autoresearch:security --diff --fix --fail-on critical
+Iterations: 15
 
 # Quick delta check in CI
-/loop 5 /autoresearch:security --diff --fail-on high
+/autoresearch:security --diff --fail-on high
+Iterations: 5
 ```
 
 **Execution order when combined:**
@@ -696,9 +701,9 @@ jobs:
         run: |
           # Delta mode on PRs, full audit on schedule
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            claude -p "/loop 5 /autoresearch:security --diff --fail-on critical"
+            claude -p "/autoresearch:security --diff --fail-on critical --iterations 5"
           else
-            claude -p "/loop 15 /autoresearch:security --fail-on high"
+            claude -p "/autoresearch:security --fail-on high --iterations 15"
           fi
 
       - name: Upload Security Report

--- a/.claude/skills/autoresearch/references/ship-workflow.md
+++ b/.claude/skills/autoresearch/references/ship-workflow.md
@@ -19,7 +19,8 @@ Works with bounded mode for iterative pre-ship preparation:
 /autoresearch:ship
 
 # Bounded preparation — iterate N times before shipping
-/loop 10 /autoresearch:ship
+/autoresearch:ship
+Iterations: 10
 
 # Ship specific artifact
 /autoresearch:ship

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -21,7 +21,8 @@ Verify: npm test -- --coverage | grep "All files"
 Bounded variant — run 20 iterations then stop:
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Increase test coverage from 72% to 90%
 Scope: src/**/*.test.ts, src/**/*.ts
 Metric: coverage % (higher is better)
@@ -33,7 +34,8 @@ Claude adds tests one-by-one. Each iteration: write test → run coverage → ke
 ### Reduce bundle size
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Reduce production bundle size
 Scope: src/**/*.tsx, src/**/*.ts
 Metric: bundle size in KB (lower is better)
@@ -45,7 +47,8 @@ Claude tries: tree-shaking unused imports, lazy-loading routes, replacing heavy 
 ### Fix flaky tests
 
 ```
-/loop 10 /autoresearch
+/autoresearch
+Iterations: 10
 Goal: Zero flaky tests (all tests pass 5 consecutive runs)
 Scope: src/**/*.test.ts
 Metric: failure count across 5 runs (lower is better)
@@ -65,7 +68,8 @@ Verify: npm run bench:api | grep "p95"
 Quick 30-minute sprint:
 
 ```
-/loop 10 /autoresearch
+/autoresearch
+Iterations: 10
 Goal: API response time under 100ms (p95)
 Scope: src/api/**/*.ts, src/services/**/*.ts
 Metric: p95 response time in ms (lower is better)
@@ -75,7 +79,8 @@ Verify: npm run bench:api | grep "p95"
 ### Eliminate TypeScript `any` types
 
 ```
-/loop 25 /autoresearch
+/autoresearch
+Iterations: 25
 Goal: Eliminate all TypeScript `any` types
 Scope: src/**/*.ts
 Metric: count of `any` occurrences (lower is better)
@@ -85,7 +90,8 @@ Verify: grep -r ":\s*any" src/ --include="*.ts" | wc -l
 ### Reduce lines of code
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Reduce lines of code in src/services/ by 30% while keeping all tests green
 Metric: LOC count (lower is better)
 Verify: npm test && find src/services -name "*.ts" | xargs wc -l | tail -1
@@ -98,7 +104,8 @@ Verify: npm test && find src/services -name "*.ts" | xargs wc -l | tail -1
 ### Cold email optimization
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Improve cold email reply rate prediction score
 Scope: content/email-templates/*.md
 Metric: readability score + personalization token count (higher is better)
@@ -110,7 +117,8 @@ Claude iterates on subject lines, opening hooks, CTAs, personalization variables
 ### Sales deck refinement
 
 ```
-/loop 10 /autoresearch
+/autoresearch
+Iterations: 10
 Goal: Reduce slide count while maintaining all key points
 Scope: content/sales-deck/*.md
 Metric: slide count (lower is better), constraint: key-points-checklist.md must all be present
@@ -120,7 +128,8 @@ Verify: node scripts/check-deck-coverage.js && wc -l content/sales-deck/*.md
 ### Objection handling docs
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Cover all 20 common objections with responses under 50 words each
 Scope: content/objection-responses.md
 Metric: objections covered + avg word count per response (more covered + fewer words = better)
@@ -144,14 +153,16 @@ Verify: node scripts/seo-score.js --file content/blog/target-post.md
 Claude tweaks headings, keyword density, meta descriptions, internal links — one change per iteration. Run unlimited overnight, or bounded:
 
 ```
-/loop 25 /autoresearch
+/autoresearch
+Iterations: 25
 Goal: Maximize SEO score for target keywords
 ```
 
 ### Landing page copy
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Maximize Flesch readability + keyword density for "AI automation"
 Scope: content/landing-pages/ai-automation.md
 Metric: readability_score * 0.7 + keyword_density_score * 0.3 (higher is better)
@@ -161,7 +172,8 @@ Verify: node scripts/content-score.js content/landing-pages/ai-automation.md
 ### Email sequence optimization
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Optimize 7-day nurture sequence for clarity and CTA strength
 Scope: content/email-sequences/onboarding/*.md
 Metric: avg readability + CTA score per email (higher is better)
@@ -171,7 +183,8 @@ Verify: node scripts/score-email-sequence.js onboarding
 ### Ad copy variants
 
 ```
-/loop 25 /autoresearch
+/autoresearch
+Iterations: 25
 Goal: Generate and refine 20 ad copy variants, each under 90 chars with power words
 Scope: content/ads/facebook-q1.md
 Metric: variants meeting criteria (higher is better)
@@ -185,7 +198,8 @@ Verify: node scripts/validate-ad-copy.js
 ### Job description optimization
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Improve job descriptions — bias-free language, clear requirements, inclusive tone
 Scope: content/job-descriptions/*.md
 Metric: inclusivity score from textio-style checker (higher is better)
@@ -195,7 +209,8 @@ Verify: node scripts/jd-inclusivity-score.js
 ### Policy document clarity
 
 ```
-/loop 10 /autoresearch
+/autoresearch
+Iterations: 10
 Goal: Reduce average reading level of HR policies to grade 8
 Scope: content/policies/*.md
 Metric: Flesch-Kincaid grade level (lower is better)
@@ -205,7 +220,8 @@ Verify: node scripts/readability.js content/policies/
 ### Interview question bank
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Ensure all questions are behavioral (STAR format) + cover all competencies
 Scope: content/interview-questions.md
 Metric: STAR-format compliance % + competency coverage % (higher is better)
@@ -219,7 +235,8 @@ Verify: node scripts/interview-quality.js
 ### Runbook optimization
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Reduce average runbook steps while maintaining completeness
 Scope: docs/runbooks/*.md
 Metric: avg steps per runbook (lower is better), constraint: all checklist items preserved
@@ -229,7 +246,8 @@ Verify: node scripts/runbook-audit.js
 ### Process documentation
 
 ```
-/loop 10 /autoresearch
+/autoresearch
+Iterations: 10
 Goal: Standardize all SOPs to template format with <100 words per step
 Scope: docs/sops/*.md
 Metric: template compliance % + avg words per step (higher compliance + lower words = better)
@@ -239,7 +257,8 @@ Verify: node scripts/sop-score.js
 ### Incident response playbooks
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Ensure all playbooks have decision trees, escalation paths, rollback steps
 Scope: docs/incident-playbooks/*.md
 Metric: completeness checklist score (higher is better)
@@ -253,7 +272,8 @@ Verify: node scripts/playbook-completeness.js
 ### Google Ads copy optimization
 
 ```
-/loop 30 /autoresearch
+/autoresearch
+Iterations: 30
 Goal: Generate 50 ad headline variants (max 30 chars) with power words + CTA
 Scope: content/ads/google-search/*.md
 Metric: headlines meeting char limit + power word + CTA criteria (higher is better)
@@ -265,7 +285,8 @@ Claude generates headline variants, scores each for character limits, emotional 
 ### Landing page CRO
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Maximize landing page quality score — clear CTA, social proof, urgency, mobile-friendly
 Scope: content/landing-pages/product-launch.md
 Metric: CRO checklist score (higher is better)
@@ -275,7 +296,8 @@ Verify: node scripts/cro-score.js content/landing-pages/product-launch.md
 ### Meta/Facebook ad copy
 
 ```
-/loop 25 /autoresearch
+/autoresearch
+Iterations: 25
 Goal: Create 30 primary text variants (max 125 chars) optimized for engagement
 Scope: content/ads/meta/*.md
 Metric: variants meeting criteria + avg engagement score (higher is better)
@@ -285,7 +307,8 @@ Verify: node scripts/meta-ad-validator.js
 ### A/B test hypothesis generation
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Generate 20 testable hypotheses for checkout page, each with metric + expected lift
 Scope: content/experiments/checkout-hypotheses.md
 Metric: valid hypotheses with metric + lift prediction (higher is better)
@@ -295,7 +318,8 @@ Verify: node scripts/hypothesis-validator.js
 ### UTM campaign taxonomy
 
 ```
-/loop 10 /autoresearch
+/autoresearch
+Iterations: 10
 Goal: Standardize all campaign URLs with consistent UTM parameters
 Scope: content/campaigns/utm-tracker.csv
 Metric: UTM compliance % (higher is better)
@@ -305,7 +329,8 @@ Verify: node scripts/utm-validator.js
 ### Email subject line testing
 
 ```
-/loop 30 /autoresearch
+/autoresearch
+Iterations: 30
 Goal: Generate 40 subject lines for product launch — max 50 chars, personalization token, urgency
 Scope: content/emails/subject-lines.md
 Metric: lines meeting all criteria (higher is better)
@@ -319,7 +344,8 @@ Verify: node scripts/subject-line-scorer.js
 ### Data pipeline quality
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Increase data validation pass rate from 85% to 99%
 Scope: scripts/validators/*.py
 Metric: validation pass rate % (higher is better)
@@ -329,7 +355,8 @@ Verify: python scripts/run_validations.py | grep "pass_rate"
 ### SQL query optimization
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Reduce total query execution time for dashboard queries
 Scope: queries/dashboard/*.sql
 Metric: total execution time in ms (lower is better)
@@ -339,7 +366,8 @@ Verify: psql -f scripts/bench-queries.sql | grep "total_ms"
 ### Report template automation
 
 ```
-/loop 10 /autoresearch
+/autoresearch
+Iterations: 10
 Goal: Standardize all weekly reports — consistent sections, KPI coverage, action items
 Scope: templates/reports/*.md
 Metric: template compliance score (higher is better)
@@ -363,7 +391,8 @@ Verify: uv run train.py --epochs 1 2>&1 | grep "val_bpb" | tail -1 | awk '{print
 ### Dockerfile optimization
 
 ```
-/loop 10 /autoresearch
+/autoresearch
+Iterations: 10
 Goal: Reduce Docker image size and build time
 Scope: Dockerfile, .dockerignore
 Metric: image size in MB (lower is better)
@@ -373,7 +402,8 @@ Verify: docker build -t bench . 2>&1 && docker images bench --format "{{.Size}}"
 ### CI/CD pipeline speed
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Reduce CI pipeline duration from 12min to under 5min
 Scope: .github/workflows/*.yml
 Metric: pipeline duration in seconds (lower is better)
@@ -383,7 +413,8 @@ Verify: node scripts/estimate-ci-time.js
 ### Terraform/IaC compliance
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Pass all tfsec security checks + reduce resource count
 Scope: infra/*.tf
 Metric: tfsec violations (lower is better)
@@ -397,7 +428,8 @@ Verify: tfsec . --format json | jq '.results | length'
 ### Accessibility audit
 
 ```
-/loop 25 /autoresearch
+/autoresearch
+Iterations: 25
 Goal: Reach WCAG 2.1 AA compliance — zero axe violations
 Scope: src/components/**/*.tsx
 Metric: axe violation count (lower is better)
@@ -407,7 +439,8 @@ Verify: npx playwright test a11y.spec.ts | grep "violations"
 ### Design token consistency
 
 ```
-/loop 20 /autoresearch
+/autoresearch
+Iterations: 20
 Goal: Replace all hardcoded colors/spacing with design tokens
 Scope: src/**/*.tsx, src/**/*.css
 Metric: hardcoded values count (lower is better)
@@ -438,7 +471,8 @@ Scope: src/api/**/*.ts
 ### Bounded bug hunt
 
 ```
-/loop 20 /autoresearch:debug
+/autoresearch:debug
+Iterations: 20
 Scope: src/auth/**/*.ts
 ```
 
@@ -474,7 +508,8 @@ Symptom: Regular users can access admin endpoints
 ### Example debug session output
 
 ```
-> /loop 10 /autoresearch:debug
+> /autoresearch:debug
+> Iterations: 10
 
 [Phase 1] Gathering symptoms...
   Tests: 3 failures, Lint: 0 errors, Types: 2 errors
@@ -535,16 +570,19 @@ Fixes type errors while ensuring tests keep passing.
 
 ```
 # Step 1: Hunt bugs
-/loop 15 /autoresearch:debug
+/autoresearch:debug
+Iterations: 15
 
 # Step 2: Fix what was found
-/loop 30 /autoresearch:fix --from-debug
+/autoresearch:fix --from-debug
+Iterations: 30
 ```
 
 ### Bounded fix sprint
 
 ```
-/loop 20 /autoresearch:fix
+/autoresearch:fix
+Iterations: 20
 ```
 
 Fix as many errors as possible in 20 iterations.
@@ -792,7 +830,8 @@ I'm going to sleep — iterate all night. Don't ask me anything.
 ### Pattern 2: "Controlled Sprint"
 
 ```
-/loop 15 /autoresearch
+/autoresearch
+Iterations: 15
 Goal: Increase test coverage from 72% to 85%
 Focus on the modules with lowest coverage first.
 ```
@@ -957,7 +996,8 @@ Launch now? → [Unlimited] [Bounded] [Copy only]
 /autoresearch:security
 
 # Bounded — exactly 10 security sweep iterations
-/loop 10 /autoresearch:security
+/autoresearch:security
+Iterations: 10
 
 # With focused scope
 /autoresearch:security
@@ -1043,7 +1083,8 @@ Each iteration targets uncovered OWASP categories:
 ### Example session output
 
 ```
-> /loop 10 /autoresearch:security
+> /autoresearch:security
+> Iterations: 10
 
 [Setup] Scanning codebase...
   Tech stack: Next.js 16, TypeScript, MongoDB, JWT auth
@@ -1107,7 +1148,7 @@ Higher = more thorough. Max theoretical: 100.
 | `--fix` | Auto-fix confirmed Critical/High after audit |
 | `--fail-on <severity>` | Exit non-zero for CI/CD gating (`critical`, `high`, `medium`) |
 
-Flags combine: `/loop 15 /autoresearch:security --diff --fix --fail-on critical`
+Flags combine: `/autoresearch:security --diff --fix --fail-on critical --iterations 15`
 
 Execution order: `--diff` narrows scope → audit runs → `--fix` remediates → `--fail-on` gates remaining findings.
 
@@ -1132,9 +1173,9 @@ jobs:
       - name: Run Security Audit
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            claude -p "/loop 5 /autoresearch:security --diff --fail-on critical"
+            claude -p "/autoresearch:security --diff --fail-on critical --iterations 5"
           else
-            claude -p "/loop 15 /autoresearch:security --fail-on high"
+            claude -p "/autoresearch:security --fail-on high --iterations 15"
           fi
       - name: Upload Report
         uses: actions/upload-artifact@v4
@@ -1147,13 +1188,13 @@ jobs:
 
 | Scenario | Recommendation |
 |----------|---------------|
-| Before a major release | `/loop 15 /autoresearch:security` |
-| Quick sanity check | `/loop 5 /autoresearch:security` |
+| Before a major release | `/autoresearch:security` with `Iterations: 15` |
+| Quick sanity check | `/autoresearch:security` with `Iterations: 5` |
 | Comprehensive overnight | `/autoresearch:security` (unlimited) |
-| CI/CD gate | `/loop 10 /autoresearch:security --fail-on critical` |
-| PR review (changed files) | `/loop 5 /autoresearch:security --diff` |
+| CI/CD gate | `/autoresearch:security --fail-on critical --iterations 10` |
+| PR review (changed files) | `/autoresearch:security --diff --iterations 5` |
 | After auth/API changes | `/autoresearch:security --diff --fix` |
-| Compliance preparation | `/loop 20 /autoresearch:security` |
+| Compliance preparation | `/autoresearch:security` with `Iterations: 20` |
 
 ---
 
@@ -1195,7 +1236,8 @@ Target: decks/q1-enterprise-proposal.pdf
 ### Iterate on readiness then ship
 
 ```
-/loop 5 /autoresearch:ship
+/autoresearch:ship
+Iterations: 5
 ```
 
 ### Just check readiness
@@ -1214,10 +1256,10 @@ Target: decks/q1-enterprise-proposal.pdf
 
 ```bash
 # Full combo: delta security + auto-fix + CI gate
-/loop 15 /autoresearch:security --diff --fix --fail-on critical
+/autoresearch:security --diff --fix --fail-on critical --iterations 15
 
 # Quick delta check, block on criticals
-/loop 5 /autoresearch:security --diff --fail-on critical
+/autoresearch:security --diff --fail-on critical --iterations 5
 
 # Overnight comprehensive + auto-remediation
 /autoresearch:security --fix
@@ -1234,8 +1276,8 @@ Target: decks/q1-enterprise-proposal.pdf
 # Ship with post-deploy monitoring (10 minutes)
 /autoresearch:ship --type deployment --monitor 10
 
-# Iterate on readiness
-/loop 5 /autoresearch:ship
+# Iterate on readiness (5 preparation iterations)
+/autoresearch:ship --iterations 5
 
 # Just check if ready
 /autoresearch:ship --checklist-only
@@ -1342,26 +1384,25 @@ Adapt the loop to your domain. The **principles** are universal; the **metrics**
 
 ---
 
-## Controlled Iterations with `/loop`
+## Bounded Iterations
 
-> **Requires:** Claude Code **v1.0.32+**
-
-By default, autoresearch loops **forever**. Use `/loop N` for fixed iterations.
+By default, autoresearch loops **forever**. Add `Iterations: N` to your inline config for fixed iterations.
 
 ```
-/loop 25 /autoresearch
+/autoresearch
 Goal: Increase test coverage to 90%
+Iterations: 25
 ```
 
-### When to use bounded loops
+### When to use bounded iterations
 
 | Scenario | Recommendation |
 |----------|---------------|
 | Run overnight | Unlimited (default) |
-| Quick 30-min session | `/loop 10 /autoresearch` |
-| Targeted fix | `/loop 5 /autoresearch` |
-| Exploratory | `/loop 15 /autoresearch` |
-| CI/CD integration | `/loop N /autoresearch` (set N based on time budget) |
+| Quick 30-min session | `Iterations: 10` |
+| Targeted fix | `Iterations: 5` |
+| Exploratory | `Iterations: 15` |
+| CI/CD integration | `--iterations N` flag (set N based on time budget) |
 
 ### Final summary format
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.3.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 [![Follow @iuditg](https://img.shields.io/badge/Follow-@iuditg-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/follow?screen_name=iuditg)
@@ -80,7 +80,7 @@ Before looping, Claude performs a one-time setup:
 | Command | What it does |
 |---------|--------------|
 | `/autoresearch` | Run the autonomous iteration loop (unlimited) |
-| `/loop N /autoresearch` | Run exactly N iterations then stop |
+| `Iterations: N` | Add to inline config to run exactly N iterations then stop |
 | `/autoresearch:plan` | Interactive wizard: Goal → Scope, Metric, Verify config |
 | `/autoresearch:security` | Autonomous STRIDE + OWASP + red-team security audit |
 | `/autoresearch:ship` | Universal shipping workflow (code, content, marketing, sales, research, design) |
@@ -94,12 +94,12 @@ Before looping, Claude performs a one-time setup:
 
 | I want to... | Use |
 |--------------|-----|
-| Improve test coverage / reduce bundle size / any metric | `/autoresearch` or `/loop N /autoresearch` |
+| Improve test coverage / reduce bundle size / any metric | `/autoresearch` (add `Iterations: N` for bounded runs) |
 | Don't know what metric to use | `/autoresearch:plan` |
 | Run a security audit | `/autoresearch:security` |
 | Ship a PR / deployment / release | `/autoresearch:ship` |
 | Optimize without breaking existing tests | Add `Guard: npm test` |
-| Hunt all bugs in a codebase | `/autoresearch:debug` or `/loop 20 /autoresearch:debug` |
+| Hunt all bugs in a codebase | `/autoresearch:debug` (add `Iterations: 20` for bounded runs) |
 | Fix all errors (tests, types, lint) | `/autoresearch:fix` |
 | Debug then auto-fix | `/autoresearch:debug --fix` |
 | Check if something is ready to ship | `/autoresearch:ship --checklist-only` |
@@ -187,7 +187,8 @@ The wizard walks you through 5 steps: capture goal → define scope → define m
 Read-only security audit using STRIDE threat modeling, OWASP Top 10 sweeps, and red-team adversarial analysis with 4 hostile personas.
 
 ```
-/loop 10 /autoresearch:security
+/autoresearch:security
+Iterations: 10
 ```
 
 **What it does:** Codebase recon → asset inventory → trust boundaries → STRIDE threat model → attack surface map → autonomous testing loop → structured report.
@@ -233,9 +234,10 @@ Auto-detects what you're shipping (code PR, deployment, blog post, email campaig
 Scientific method meets autoresearch loop. Doesn't stop at one bug — iteratively hunts ALL bugs using falsifiable hypotheses, evidence-based investigation, and 7 investigation techniques.
 
 ```
-/loop 20 /autoresearch:debug
+/autoresearch:debug
 Scope: src/api/**/*.ts
 Symptom: API returns 500 on POST /users
+Iterations: 20
 ```
 
 **How it works:** Gather symptoms → Recon (map error surface) → Hypothesize (specific, testable) → Test (one experiment per iteration) → Classify (confirmed/disproven/inconclusive) → Log → Repeat.
@@ -270,7 +272,7 @@ Takes a broken state and iteratively repairs it until everything passes. ONE fix
 | `--category <type>` | Only fix specific type (test, type, lint, build) |
 | `--from-debug` | Read findings from latest debug session |
 
-**Chain them:** `/loop 15 /autoresearch:debug` then `/loop 30 /autoresearch:fix --from-debug`
+**Chain them:** Run `/autoresearch:debug` with `Iterations: 15`, then `/autoresearch:fix --from-debug` with `Iterations: 30`
 
 ---
 
@@ -364,7 +366,7 @@ A: Run `/autoresearch:plan` — it analyzes your codebase, suggests metrics, and
 A: Yes. Any language, framework, or domain. Copy the skill to `.claude/skills/autoresearch/` and the commands to `.claude/commands/autoresearch/`.
 
 **Q: How do I stop the loop?**
-A: `Ctrl+C` or use `/loop N /autoresearch` to run exactly N iterations. Claude commits before verifying, so your last successful state is always in git.
+A: `Ctrl+C` or add `Iterations: N` to your inline config to run exactly N iterations. Claude commits before verifying, so your last successful state is always in git.
 
 **Q: Can I use this for non-code tasks?**
 A: Absolutely. Sales emails, marketing copy, HR policies, runbooks — anything with a measurable metric. See [EXAMPLES.md](EXAMPLES.md).

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports optional loop count via Claude Code's /loop command.
-version: 1.3.3
+description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+version: 1.4.0
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
@@ -59,7 +59,8 @@ Load: `references/security-workflow.md` for full protocol.
 /autoresearch:security
 
 # Bounded — exactly 10 security sweep iterations
-/loop 10 /autoresearch:security
+/autoresearch:security
+Iterations: 10
 
 # With focused scope
 /autoresearch:security
@@ -70,13 +71,16 @@ Focus: authentication and authorization flows
 /autoresearch:security --diff
 
 # Auto-fix confirmed Critical/High findings after audit
-/loop 15 /autoresearch:security --fix
+/autoresearch:security --fix
+Iterations: 15
 
 # CI/CD gate — fail pipeline if any Critical findings
-/loop 10 /autoresearch:security --fail-on critical
+/autoresearch:security --fail-on critical
+Iterations: 10
 
 # Combined — delta audit + fix + gate
-/loop 15 /autoresearch:security --diff --fix --fail-on critical
+/autoresearch:security --diff --fix --fail-on critical
+Iterations: 15
 ```
 
 **Inspired by:**
@@ -143,7 +147,8 @@ Load: `references/ship-workflow.md` for full protocol.
 /autoresearch:ship --monitor 10
 
 # Prepare iteratively then ship
-/loop 5 /autoresearch:ship
+/autoresearch:ship
+Iterations: 5
 
 # Just check if something is ready to ship
 /autoresearch:ship --checklist-only
@@ -220,13 +225,9 @@ After the wizard completes, the user gets a ready-to-paste `/autoresearch` invoc
 - User says "work autonomously", "iterate until done", "keep improving", "run overnight" → run the loop
 - Any task requiring repeated iteration cycles with measurable outcomes → run the loop
 
-## Optional: Controlled Loop Count
+## Bounded Iterations
 
-By default, autoresearch loops **forever** until manually interrupted. However, users can optionally specify a **loop count** to limit iterations using Claude Code's built-in `/loop` command.
-
-> **Requires:** Claude Code v1.0.32+ (the `/loop` command was introduced in this version)
-
-### Usage
+By default, autoresearch loops **forever** until manually interrupted. To run exactly N iterations, add `Iterations: N` to your inline config.
 
 **Unlimited (default):**
 ```
@@ -236,29 +237,22 @@ Goal: Increase test coverage to 90%
 
 **Bounded (N iterations):**
 ```
-/loop 25 /autoresearch
+/autoresearch
 Goal: Increase test coverage to 90%
+Iterations: 25
 ```
 
-This chains `/autoresearch` with `/loop 25`, running exactly 25 iteration cycles. After 25 iterations, Claude stops and prints a final summary.
+After N iterations Claude stops and prints a final summary with baseline → current best, keeps/discards/crashes. If the goal is achieved before N iterations, Claude prints early completion and stops.
 
-### When to Use Bounded Loops
+### When to Use Bounded Iterations
 
 | Scenario | Recommendation |
 |----------|---------------|
 | Run overnight, review in morning | Unlimited (default) |
-| Quick 30-min improvement session | `/loop 10 /autoresearch` |
-| Targeted fix with known scope | `/loop 5 /autoresearch` |
-| Exploratory — see if approach works | `/loop 15 /autoresearch` |
-| CI/CD pipeline integration | `/loop N /autoresearch` (set N based on time budget) |
-
-### Behavior with Loop Count
-
-When a loop count is specified:
-- Claude runs exactly N iterations through the autoresearch loop
-- After iteration N, Claude prints a **final summary** with baseline → current best, keeps/discards/crashes
-- If the goal is achieved before N iterations, Claude prints early completion and stops
-- All other rules (atomic changes, mechanical verification, auto-rollback) still apply
+| Quick 30-min improvement session | `Iterations: 10` |
+| Targeted fix with known scope | `Iterations: 5` |
+| Exploratory — see if approach works | `Iterations: 15` |
+| CI/CD pipeline integration | `--iterations N` flag (set N based on time budget) |
 
 ## Setup Phase (Do Once)
 
@@ -287,7 +281,7 @@ Use a SINGLE `AskUserQuestion` call with these 4 questions:
 |---|--------|----------|---------|
 | 5 | `Verify` | "What command produces the metric? (I'll dry-run it to confirm)" | Suggested commands from detected tooling |
 | 6 | `Guard` | "Any command that must ALWAYS pass? (prevents regressions)" | "npm test", "tsc --noEmit", "npm run build", "Skip — no guard" |
-| 7 | `Launch` | "Ready to go?" | "Launch (unlimited)", "Launch with /loop N", "Edit config", "Cancel" |
+| 7 | `Launch` | "Ready to go?" | "Launch (unlimited)", "Launch with iteration limit", "Edit config", "Cancel" |
 
 **After Batch 2:** Dry-run the verify command. If it fails, ask user to fix or choose a different command. If it passes, proceed with launch choice.
 

--- a/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -7,7 +7,7 @@ Detailed protocol for the autoresearch iteration loop. SKILL.md has the summary;
 Autoresearch supports two loop modes:
 
 - **Unbounded (default):** Loop forever until manually interrupted (`Ctrl+C`)
-- **Bounded:** Loop exactly N times when chained with `/loop N` (requires Claude Code v1.0.32+)
+- **Bounded:** Loop exactly N times when `Iterations: N` is set in the inline config (or `--iterations N` flag for CLI/CI)
 
 When bounded, track `current_iteration` against `max_iterations`. After the final iteration, print a summary and stop.
 
@@ -152,7 +152,7 @@ iteration  commit   metric   status   description
 
 Go to Phase 1. **NEVER STOP. NEVER ASK IF YOU SHOULD CONTINUE.**
 
-### Bounded Mode (with /loop N)
+### Bounded Mode (with Iterations: N)
 
 ```
 IF current_iteration < max_iterations:

--- a/skills/autoresearch/references/debug-workflow.md
+++ b/skills/autoresearch/references/debug-workflow.md
@@ -17,7 +17,8 @@ Autonomous bug-hunting loop that applies the scientific method iteratively. Does
 /autoresearch:debug
 
 # Bounded — exactly N investigation iterations
-/loop 20 /autoresearch:debug
+/autoresearch:debug
+Iterations: 20
 
 # Focused scope
 /autoresearch:debug
@@ -454,8 +455,11 @@ Creates `debug/{YYMMDD}-{HHMM}-{debug-slug}/` with:
 /autoresearch:debug --fix
 
 # Or manually chain
-/loop 15 /autoresearch:debug    # hunt bugs
-/loop 20 /autoresearch:fix      # fix everything found
+/autoresearch:debug
+Iterations: 15
+
+/autoresearch:fix
+Iterations: 20
 ```
 
 When `--fix` is specified, after the debug loop completes, automatically switches to `/autoresearch:fix` targeting the discovered issues.

--- a/skills/autoresearch/references/fix-workflow.md
+++ b/skills/autoresearch/references/fix-workflow.md
@@ -17,7 +17,8 @@ Autonomous fix loop that takes a broken state and iteratively repairs it until e
 /autoresearch:fix
 
 # Bounded — exactly N fix iterations
-/loop 30 /autoresearch:fix
+/autoresearch:fix
+Iterations: 30
 
 # With explicit target
 /autoresearch:fix
@@ -41,7 +42,7 @@ Use ONE `AskUserQuestion` call with all 4 questions:
 | 1 | `Fix What` | "Found [N] test failures, [M] type errors, [K] lint errors. What should I fix?" | "Fix everything (recommended)", "Only tests", "Only type errors", "Only lint" |
 | 2 | `Guard` | "What command must ALWAYS pass? (prevents fixes from breaking other things)" | "npm test", "tsc --noEmit", "npm run build", "Skip — no guard" |
 | 3 | `Scope` | "Which files can I modify?" | Suggested globs from error locations + "All project files" |
-| 4 | `Launch` | "Ready to fix?" | "Fix until zero errors", "Fix with /loop N", "Edit config", "Cancel" |
+| 4 | `Launch` | "Ready to fix?" | "Fix until zero errors", "Fix with iteration limit", "Edit config", "Cancel" |
 
 **IMPORTANT:** Always ask all 4 questions in a single call — never one at a time. Users need the full picture (what's broken, what's the guard, what's the scope) to make informed decisions together.
 
@@ -583,8 +584,11 @@ When errors appear only in CI (not locally):
 
 ```bash
 # Debug first, then fix what was found
-/loop 15 /autoresearch:debug
-/loop 30 /autoresearch:fix --from-debug
+/autoresearch:debug
+Iterations: 15
+
+/autoresearch:fix --from-debug
+Iterations: 30
 
 # Fix with guard
 /autoresearch:fix
@@ -598,7 +602,8 @@ Guard: npm test
 /autoresearch:fix
 
 # Bounded sprint — fix as many as you can in 20 iterations
-/loop 20 /autoresearch:fix
+/autoresearch:fix
+Iterations: 20
 ```
 
 ## Output Directory
@@ -613,8 +618,12 @@ Creates `fix/{YYMMDD}-{HHMM}-{fix-slug}/` with:
 
 ```bash
 # Full pipeline: debug → fix → ship
-/loop 15 /autoresearch:debug
-/loop 30 /autoresearch:fix --from-debug --guard "npm test"
+/autoresearch:debug
+Iterations: 15
+
+/autoresearch:fix --from-debug --guard "npm test"
+Iterations: 30
+
 /autoresearch:ship
 
 # Fix only critical issues, then verify clean

--- a/skills/autoresearch/references/plan-workflow.md
+++ b/skills/autoresearch/references/plan-workflow.md
@@ -213,7 +213,7 @@ AskUserQuestion:
 ```
 
 If "Launch now — unlimited": invoke `/autoresearch` with the configuration.
-If "Launch now — bounded": ask for iteration count, then invoke `/loop N /autoresearch`.
+If "Launch now — bounded": ask for iteration count, then invoke `/autoresearch` with `Iterations: N` in the inline config.
 If "Copy config only": output the ready-to-paste command block and stop.
 
 ## Metric Suggestion Database

--- a/skills/autoresearch/references/security-workflow.md
+++ b/skills/autoresearch/references/security-workflow.md
@@ -19,7 +19,8 @@ Works with both unbounded and bounded modes:
 /autoresearch:security
 
 # Bounded — run exactly N security sweep iterations
-/loop 10 /autoresearch:security
+/autoresearch:security
+Iterations: 10
 
 # With target scope
 /autoresearch:security
@@ -263,7 +264,7 @@ iteration	vector	severity	owasp	stride	confidence	location	description
 #### Phase 6: Repeat
 
 - **Unbounded:** Keep finding vulnerabilities. Never stop. Never ask.
-- **Bounded (/loop N):** After N iterations, generate final report and stop.
+- **Bounded (Iterations: N):** After N iterations, generate final report and stop.
 - **Coverage tracking:** Every 5 iterations, print coverage summary.
 
 ### Coverage Summary Format
@@ -475,7 +476,7 @@ Never report a finding without proof. For each vulnerability:
 4. Show the impact (data leaked, access gained, etc.)
 
 ### Multi-Agent Attack Collaboration
-When using `/loop`, each iteration should build on prior findings:
+Each iteration should build on prior findings:
 - Iteration 1 finds open endpoint → Iteration 2 chains with IDOR
 - Iteration 3 finds missing rate limit → Iteration 4 tests brute force feasibility
 - Findings compound. Each iteration reads past findings for chaining opportunities.
@@ -580,7 +581,7 @@ Exit with non-zero code if findings meet or exceed a severity threshold. Designe
 **CI/CD usage:**
 ```bash
 # In GitHub Actions or CI scripts
-/loop 10 /autoresearch:security --fail-on critical
+claude -p "/autoresearch:security --fail-on critical --iterations 10"
 # Exit code 1 if any Critical findings → blocks the pipeline
 ```
 
@@ -590,7 +591,9 @@ After completing the audit, switches to standard autoresearch modify→verify lo
 
 ```
 /autoresearch:security --fix
-/loop 10 /autoresearch:security --fix
+
+/autoresearch:security --fix
+Iterations: 10
 ```
 
 **How it works:**
@@ -631,10 +634,12 @@ Flags can be combined:
 
 ```
 # Delta audit + auto-fix critical/high + block on remaining criticals
-/loop 15 /autoresearch:security --diff --fix --fail-on critical
+/autoresearch:security --diff --fix --fail-on critical
+Iterations: 15
 
 # Quick delta check in CI
-/loop 5 /autoresearch:security --diff --fail-on high
+/autoresearch:security --diff --fail-on high
+Iterations: 5
 ```
 
 **Execution order when combined:**
@@ -696,9 +701,9 @@ jobs:
         run: |
           # Delta mode on PRs, full audit on schedule
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            claude -p "/loop 5 /autoresearch:security --diff --fail-on critical"
+            claude -p "/autoresearch:security --diff --fail-on critical --iterations 5"
           else
-            claude -p "/loop 15 /autoresearch:security --fail-on high"
+            claude -p "/autoresearch:security --fail-on high --iterations 15"
           fi
 
       - name: Upload Security Report

--- a/skills/autoresearch/references/ship-workflow.md
+++ b/skills/autoresearch/references/ship-workflow.md
@@ -19,7 +19,8 @@ Works with bounded mode for iterative pre-ship preparation:
 /autoresearch:ship
 
 # Bounded preparation — iterate N times before shipping
-/loop 10 /autoresearch:ship
+/autoresearch:ship
+Iterations: 10
 
 # Ship specific artifact
 /autoresearch:ship


### PR DESCRIPTION
## Summary

Fixes #24 — `/loop 5 /autoresearch` triggers Claude's scheduler (cron-like behavior) instead of limiting to 5 iterations.

### Root Cause

Claude Code's `/loop` command is a **scheduler** that runs commands on time intervals (e.g., `/loop 5m /foo` = run every 5 minutes). When users typed `/loop 5 /autoresearch`, Claude interpreted "5" as "5 minutes" and scheduled a recurring task — not 5 iterations.

All autoresearch documentation incorrectly suggested `/loop N /autoresearch` for bounded iterations.

### Fix

Replaced ALL `/loop N` references with native **`Iterations: N`** inline config:

**Before (broken):**
```
/loop 25 /autoresearch
Goal: Increase test coverage to 90%
```

**After (correct):**
```
/autoresearch
Goal: Increase test coverage to 90%
Iterations: 25
```

For CI/CD contexts, use `--iterations N` flag:
```bash
claude -p "/autoresearch:security --diff --fail-on critical --iterations 5"
```

### Scope

- 16 files updated across `skills/`, `.claude/skills/`, `README.md`, `EXAMPLES.md`
- Zero `/loop` references remain in the entire codebase
- Version bumped to 1.4.0 (minor bump — behavior change)

### Files Changed

| Category | Files |
|----------|-------|
| **Core skill** | `SKILL.md` (both locations) |
| **References** | `autonomous-loop-protocol.md`, `debug-workflow.md`, `fix-workflow.md`, `security-workflow.md`, `ship-workflow.md`, `plan-workflow.md` (both locations) |
| **Docs** | `README.md`, `EXAMPLES.md` |

## Test plan

- [x] Zero `/loop` references remain (grep verified)
- [x] `Iterations: N` syntax documented consistently across all files
- [x] `--iterations N` flag documented for CI/CD usage
- [x] Version bumped to 1.4.0 in SKILL.md and README badge
- [x] Both `skills/` and `.claude/skills/` are in sync