### PR TITLE
fix: bump plugin.json version from 1.3.0 to 1.6.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
   "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. Includes planning wizard, security audit, shipping workflow, autonomous debugger, and autonomous fixer.",
-  "version": "1.3.0",
+  "version": "1.6.1",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"


### PR DESCRIPTION
## Summary

- Bumps `version` in `.claude-plugin/plugin.json` from `1.3.0` to `1.6.1` to match the latest GitHub release

The version field was never updated past 1.3.0, so Claude Code reports the wrong version after installation via `/plugin install`.

Fixes #32