### PR TITLE
fix: remove self-referencing source URL causing recursive directory nesting

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "1.3.0",
+  "version": "1.6.1",
   "description": "Claude Autoresearch — autonomous goal-directed iteration for Claude Code. Inspired by Karpathy's autoresearch: constraint + mechanical metric + autonomous iteration = compounding gains.",
   "owner": {
     "name": "Udit Goenka",
@@ -11,14 +11,10 @@
     {
       "name": "autoresearch",
       "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:security (STRIDE + OWASP audit), /autoresearch:ship (multi-phase delivery workflow), /autoresearch:debug (autonomous bug hunter), and /autoresearch:fix (autonomous error crusher).",
-      "version": "1.3.0",
+      "version": "1.6.1",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"
-      },
-      "source": {
-        "source": "url",
-        "url": "https://github.com/uditgoenka/autoresearch.git"
       },
       "category": "productivity"
     }


### PR DESCRIPTION
## Summary

- Removes the self-referencing `source` URL from `.claude-plugin/marketplace.json` that causes infinite recursive directory nesting during plugin installation
- Bumps `marketplace.json` version from `1.3.0` to `1.6.1`

## Problem

The `plugins` array in `marketplace.json` contained a `source` block pointing back to this same repo:

```json
"source": {
  "source": "url",
  "url": "https://github.com/uditgoenka/autoresearch.git"
}
```

The plugin installer resolves this, clones the repo inside the install directory, which contains the same `marketplace.json`, which triggers another clone, and so on infinitely:

```
cache/autoresearch/autoresearch/1.6.1/
  autoresearch/1.6.1/
    autoresearch/1.6.1/
      autoresearch/1.6.1/
        ... (until path length limit)
```

On Windows this is especially destructive — paths exceed MAX_PATH (260 chars), making the directories undeletable with standard tools.

## Fix

Remove the `source` block from the plugin entry in `marketplace.json`. The `source` is unnecessary here since the plugin is defined within the same repository — `plugin.json` already provides the plugin metadata.

Fixes #35