### PR TITLE
fix: add required source field to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"
       },
-      "source": ".",
+      "source": "./",
       "category": "productivity"
     }
   ]


### PR DESCRIPTION
## Summary
- Adds the required `source` field (`"./"`) to the plugin entry in `marketplace.json`
- The field was removed in 4808b54 to fix recursive cloning, but it's required by the schema
- Using relative path `"./"` avoids the recursive clone issue while satisfying schema validation

## Problem
After the source field was removed, installing the marketplace produces:
```
Error: Failed to parse marketplace file: Invalid schema: plugins.0.source: Invalid input
```

## Test plan
- [x] Install the marketplace plugin and verify no schema parse error
- [x] Verify no recursive cloning occurs with `"./"` as the source path

🤖 Generated with [Claude Code](https://claude.com/claude-code)