### PR TITLE
Release v1.7.1 — Guide Restructure & Command Reliability Fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Claude Autoresearch — autonomous goal-directed iteration for Claude Code. Inspired by Karpathy's autoresearch: constraint + mechanical metric + autonomous iteration = compounding gains.",
   "owner": {
     "name": "Udit Goenka",
@@ -11,7 +11,7 @@
     {
       "name": "autoresearch",
       "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:predict (multi-persona swarm prediction), /autoresearch:security (STRIDE + OWASP audit), /autoresearch:ship (multi-phase delivery workflow), /autoresearch:debug (autonomous bug hunter), and /autoresearch:fix (autonomous error crusher).",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
   "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. Includes planning wizard, security audit, shipping workflow, autonomous debugger, and autonomous fixer.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.7.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.7.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 [![Follow @iuditg](https://img.shields.io/badge/Follow-@iuditg-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/follow?screen_name=iuditg)

--- a/guide/README.md
+++ b/guide/README.md
@@ -4,7 +4,7 @@
 
 **By [Udit Goenka](https://udit.co)**
 
-[![Version](https://img.shields.io/badge/version-1.7.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.7.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>

--- a/scripts/release.md
+++ b/scripts/release.md
@@ -21,22 +21,22 @@
 ## What the Script Does
 
 ```
-[1/6] Create release branch (release/X.Y.Z)
-[2/6] Bump versions:
+[1/7] Create release branch (release/X.Y.Z)
+[2/7] Bump versions:
       → .claude-plugin/plugin.json       (version field)
       → .claude-plugin/marketplace.json  (version fields — top-level + plugins array)
       → README.md                        (version badge)
       → guide/README.md                  (version badge)
-[3/6] Sync distribution files:
+[3/7] Sync distribution files:
       → Copies .claude/commands/autoresearch/ → commands/autoresearch/
       → Copies .claude/skills/autoresearch/  → skills/autoresearch/
       → Ensures root distribution matches .claude/ source of truth
-[4/6] Pause for doc review:
+[4/7] Pause for doc review:
       → Shows changelog since last tag
       → Prompts you to review README.md, guide/, CONTRIBUTING.md
       → You can edit in another terminal, then continue
-[5/6] Commit all release changes
-[6/6] Push branch + create PR against master
+[5/7] Commit all release changes
+[6/7] Push branch + create PR against master
 [7/7] Wait for your "merge" confirmation:
       → Merges PR
       → Tags the merge commit
@@ -54,7 +54,7 @@ Before running the script, verify:
 
 ## Doc Review Guide
 
-At step [3/6], the script pauses and shows the changelog. Review these files:
+At step [4/7], the script pauses and shows the changelog. Review these files:
 
 ### README.md
 - **Version badge** (auto-updated by script)


### PR DESCRIPTION
## Summary

Patch release addressing documentation restructure and critical command reliability issues reported by users.

### Documentation Restructure
- **Replaced monolithic GUIDE.md (1,791 lines) + EXAMPLES.md (2,228 lines)** with 13 focused guide files in `guide/` folder (6,183 lines total)
- Each subcommand now has its own detailed guide with examples, flags, chains, and tips
- `guide/autoresearch-predict.md` is the flagship guide at 778 lines
- Updated README.md, CONTRIBUTING.md, and release.sh to reference `guide/`

### Command Reliability Fixes
- **Fix: Commands not triggering on first invocation** — Removed redundant SKILL.md read (518 lines) from all 8 command files, reducing context loading by 50-65%
- **Fix: `--iterations N` not running N iterations** — Added explicit argument parsing section to all commands with `Iterations:` and `--iterations` support, iteration counter tracking, and mandatory STOP after N
- **Fix: Massive context + subcommands failing** — Commands now separate flags from prose: "Ignore prose and extract ONLY flags/config"
- **Fix: Commands running in background** — Added "Stream all output live — never run in background" to all commands
- Added `EXECUTE IMMEDIATELY` directive to prevent hesitation

### Distribution Sync
- Synced root `commands/` and `skills/autoresearch/` with `.claude/` (added predict.md, scenario.md, predict-workflow.md, scenario-workflow.md)
- Added [3/7] sync step to release.sh ensuring root distribution stays in sync automatically
- Updated release.md with distribution sync documentation

## Files Changed

| Area | Files |
|------|-------|
| Guide (new) | 13 files in `guide/` |
| Guide (removed) | `GUIDE.md`, `EXAMPLES.md` |
| Commands | All 8 `.claude/commands/autoresearch/*.md` + root mirrors |
| Distribution | `commands/`, `skills/autoresearch/` synced |
| Release | `scripts/release.sh`, `scripts/release.md` |
| Docs | `README.md`, `CONTRIBUTING.md` |
| Version | `plugin.json`, `marketplace.json` → 1.7.1 |

## Test Plan
- [ ] Invoke `/autoresearch:debug --iterations 5` — should trigger immediately and run exactly 5 iterations
- [ ] Invoke `/autoresearch:fix` with large context paragraph — should extract flags correctly
- [ ] Invoke `/autoresearch:predict --chain debug` — should stream live, not background
- [ ] Verify `guide/` links work on GitHub
- [ ] Verify root `commands/` and `skills/` match `.claude/` versions