### PR TITLE
Release v1.7.2 — Stability Fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Claude Autoresearch — autonomous goal-directed iteration for Claude Code. Inspired by Karpathy's autoresearch: constraint + mechanical metric + autonomous iteration = compounding gains.",
   "owner": {
     "name": "Udit Goenka",
@@ -11,7 +11,7 @@
     {
       "name": "autoresearch",
       "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:predict (multi-persona swarm prediction), /autoresearch:security (STRIDE + OWASP audit), /autoresearch:ship (multi-phase delivery workflow), /autoresearch:debug (autonomous bug hunter), and /autoresearch:fix (autonomous error crusher).",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
   "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. Includes planning wizard, security audit, shipping workflow, autonomous debugger, and autonomous fixer.",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"

--- a/.claude/commands/autoresearch/predict.md
+++ b/.claude/commands/autoresearch/predict.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:predict
 description: Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
-argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <dollars>] [--fail-on <severity>]"
+argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.
@@ -16,10 +16,10 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 - `--personas N` — number of personas (3-8)
 - `--rounds N` — debate rounds (1-3)
 - `--adversarial` — use red team personas
-- `--budget <$>` — max cost per session
+- `--budget <N>` — max total findings across all personas (default: 40)
 - `--fail-on <severity>` — CI/CD gate
-- `--dry-run` — show what would happen without executing
-- `Goal:` — text after "Goal:" keyword
+- `--incremental` — reuse existing knowledge files, update only changed files
+- `--goal <text>` or `Goal:` — focus area for analysis
 
 All remaining text not matching flags is the goal/focus description.
 

--- a/.claude/commands/autoresearch/security.md
+++ b/.claude/commands/autoresearch/security.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:security
 description: Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas
-argument-hint: "[--diff] [--fix] [--fail-on <severity>] [--iterations N]"
+argument-hint: "[--diff] [--fix] [--fail-on <severity>] [--scope <glob>] [--depth <level>] [--iterations N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.
@@ -12,8 +12,10 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 
 - `--diff` — only audit files changed since last audit
 - `--fix` — auto-fix confirmed Critical/High findings
-- `--fail-on <severity>` — exit non-zero for CI/CD gating
-- `Scope:` or `--scope <glob>` — file globs to audit
+- `--fail-on <severity>` — exit non-zero for CI/CD gating (critical/high/medium)
+- `--scope <glob>` or `Scope:` — file globs to audit
+- `--depth <level>` or `Depth:` — quick scan (5), standard (15), deep (30+)
+- `Focus:` — specific area to focus on (e.g., "authentication and authorization")
 - `Iterations:` or `--iterations N` — integer for bounded mode (CRITICAL: run exactly N iterations then stop)
 
 If `Iterations: N` or `--iterations N` is found, set `max_iterations = N`. Track `current_iteration` starting at 0. After iteration N, print final summary and STOP.

--- a/.claude/commands/autoresearch/ship.md
+++ b/.claude/commands/autoresearch/ship.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:ship
 description: Universal shipping workflow — ship code, content, marketing, sales, research, or anything through structured 8-phase workflow
-argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--checklist-only] [--iterations N]"
+argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--target <path>] [--checklist-only] [--iterations N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.
@@ -17,6 +17,7 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 - `--monitor N` — post-ship monitoring for N minutes
 - `--type <type>` — override auto-detection (code-pr, code-release, deployment, content, etc.)
 - `--checklist-only` — only generate checklist
+- `--target <path>` or `Target:` — what to ship (path, PR, artifact)
 - `Iterations:` or `--iterations N` — bounded preparation iterations (CRITICAL: run exactly N prep iterations then ship)
 
 If `Iterations: N` or `--iterations N` is found, set `max_iterations = N` for the preparation loop.

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
-version: 1.7.1
+version: 1.7.2
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
@@ -366,7 +366,7 @@ After the wizard completes, the user gets a ready-to-paste `/autoresearch` invoc
 
 ## When to Activate
 
-- User invokes `/autoresearch` or `/ug:autoresearch` → run the loop
+- User invokes `/autoresearch` → run the loop
 - User invokes `/autoresearch:plan` → run the planning wizard
 - User invokes `/autoresearch:security` → run the security audit
 - User says "help me set up autoresearch", "plan an autoresearch run" → run the planning wizard

--- a/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -117,9 +117,9 @@ git diff --cached --quiet
 git commit -m "experiment(<scope>): <one-sentence description of what you changed and why>"
 ```
 
-**"Nothing to commit" handling:** If `git add -A` followed by `git diff --cached --quiet` shows no changes, the modification phase produced no actual diff. This is NOT a crash — log as `status=no-op` with description of what was attempted, skip verification, and proceed to next iteration. Do NOT create an empty commit.
+**"Nothing to commit" handling:** If `git add <files>` followed by `git diff --cached --quiet` shows no changes, the modification phase produced no actual diff. This is NOT a crash — log as `status=no-op` with description of what was attempted, skip verification, and proceed to next iteration. Do NOT create an empty commit.
 
-**WARNING about `git add -A`:** This stages ALL changes in the repo, including files outside the in-scope set. Before committing, run `git diff --cached --name-only` and verify that only in-scope files are staged. If unexpected files appear, unstage them with `git reset HEAD <file>` before committing.
+**WARNING:** NEVER use `git add -A` — it stages ALL files including .env, credentials, and user's unrelated work. Always use `git add <file1> <file2> ...` with explicit file paths. After staging, verify with `git diff --cached --name-only` that only in-scope files are staged.
 
 **Commit message format:** Use conventional commit format with `experiment` type: `experiment(<scope>): <description>`. This keeps compatibility with commit-lint while clearly marking autoresearch iterations. Example: `experiment(auth): increase timeout from 5s to 30s — hypothesis: reduces flaky test failures`.
 
@@ -200,7 +200,7 @@ ELIF metric_improved AND guard_failed:
     # Rework the optimization (max 2 attempts)
     FOR attempt IN 1..2:
         Analyze guard output → rework implementation (NOT tests)
-        git add -A && git commit -m "experiment: rework — <description>"
+        git add <modified-files> && git commit -m "experiment(<scope>): rework — <description>"
         Re-run verify
         IF metric_improved:
             Re-run guard

--- a/.claude/skills/autoresearch/references/debug-workflow.md
+++ b/.claude/skills/autoresearch/references/debug-workflow.md
@@ -466,4 +466,4 @@ Iterations: 15
 Iterations: 20
 ```
 
-When `--fix` is specified, after the debug loop completes, automatically switches to `/autoresearch:fix` targeting the discovered issues.
+When `--fix` is specified, after the debug loop completes, automatically switches to `/autoresearch:fix --from-debug` targeting the discovered issues. The `--from-debug` flag tells fix to read findings from the latest debug session.

--- a/.claude/skills/autoresearch/references/fix-workflow.md
+++ b/.claude/skills/autoresearch/references/fix-workflow.md
@@ -171,7 +171,7 @@ Pick the highest-priority unfixed item and make ONE focused change.
 ## Phase 4: Commit — Before Verification
 
 ```bash
-git add -A
+git add <modified-files>
 git commit -m "fix: [what was fixed] — [file:line]"
 ```
 

--- a/.claude/skills/autoresearch/references/predict-workflow.md
+++ b/.claude/skills/autoresearch/references/predict-workflow.md
@@ -679,12 +679,12 @@ Reports older than 30 days also receive: `⚠️ Age Warning: This report is {N}
 |------|---------|---------|
 | `--scope <glob>` | Files to include in analysis | `--scope "src/api/**/*.ts"` |
 | `--goal <text>` | Focus area for all personas | `--goal "security and reliability"` |
-| `--depth <level>` | Preset (quick/standard/deep) or custom | `--depth deep` |
+| `--depth <level>` | Preset (shallow/standard/deep) | `--depth deep` |
 | `--personas <N>` | Override persona count (3-8) | `--personas 4` |
-| `--rounds <N>` | Override debate rounds (0-3) | `--rounds 1` |
+| `--rounds <N>` | Override debate rounds (1-3) | `--rounds 1` |
 | `--adversarial` | Use adversarial persona set instead of default | `--adversarial` |
 | `--chain <tools>` | Chain to downstream tool(s). Comma-separated for multi-chain | `--chain debug` or `--chain scenario,debug,fix` |
-| `--budget <dollars>` | Max LLM cost for session (default: $1.00) | `--budget 0.50` |
+| `--budget <findings>` | Max total findings across all personas (default: 40) | `--budget 20` |
 | `--fail-on <severity>` | Exit non-zero if findings at severity exist | `--fail-on critical` |
 | `--incremental` | Re-use existing knowledge files, update only changed | `--incremental` |
 
@@ -734,7 +734,7 @@ Iterations: 2
 
 # Predict → Scenario: swarm findings seed edge case exploration
 /autoresearch:predict --scope src/checkout/**/*.ts --chain scenario
-Depth: quick
+Depth: shallow
 ```
 
 ## What NOT to Do — Anti-Patterns

--- a/.claude/skills/autoresearch/references/security-workflow.md
+++ b/.claude/skills/autoresearch/references/security-workflow.md
@@ -585,7 +585,7 @@ claude -p "/autoresearch:security --fail-on critical --iterations 10"
 # Exit code 1 if any Critical findings → blocks the pipeline
 ```
 
-### `--fix` — Auto-Remediation Mode (v1.0.3)
+### `--fix` — Auto-Remediation Mode
 
 After completing the audit, switches to standard autoresearch modify→verify loop to fix confirmed findings. Uses the security audit report as its goal.
 
@@ -694,6 +694,8 @@ jobs:
         run: |
           git clone https://github.com/uditgoenka/autoresearch.git /tmp/autoresearch
           cp -r /tmp/autoresearch/skills/autoresearch .claude/skills/autoresearch
+          cp -r /tmp/autoresearch/commands/autoresearch .claude/commands/autoresearch
+          cp /tmp/autoresearch/commands/autoresearch.md .claude/commands/autoresearch.md
 
       - name: Run Security Audit
         env:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.7.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.7.2-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 [![Follow @iuditg](https://img.shields.io/badge/Follow-@iuditg-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/follow?screen_name=iuditg)

--- a/commands/autoresearch/predict.md
+++ b/commands/autoresearch/predict.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:predict
 description: Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
-argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <dollars>] [--fail-on <severity>]"
+argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.
@@ -16,10 +16,10 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 - `--personas N` — number of personas (3-8)
 - `--rounds N` — debate rounds (1-3)
 - `--adversarial` — use red team personas
-- `--budget <$>` — max cost per session
+- `--budget <N>` — max total findings across all personas (default: 40)
 - `--fail-on <severity>` — CI/CD gate
-- `--dry-run` — show what would happen without executing
-- `Goal:` — text after "Goal:" keyword
+- `--incremental` — reuse existing knowledge files, update only changed files
+- `--goal <text>` or `Goal:` — focus area for analysis
 
 All remaining text not matching flags is the goal/focus description.
 

--- a/commands/autoresearch/security.md
+++ b/commands/autoresearch/security.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:security
 description: Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas
-argument-hint: "[--diff] [--fix] [--fail-on <severity>] [--iterations N]"
+argument-hint: "[--diff] [--fix] [--fail-on <severity>] [--scope <glob>] [--depth <level>] [--iterations N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.
@@ -12,8 +12,10 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 
 - `--diff` — only audit files changed since last audit
 - `--fix` — auto-fix confirmed Critical/High findings
-- `--fail-on <severity>` — exit non-zero for CI/CD gating
-- `Scope:` or `--scope <glob>` — file globs to audit
+- `--fail-on <severity>` — exit non-zero for CI/CD gating (critical/high/medium)
+- `--scope <glob>` or `Scope:` — file globs to audit
+- `--depth <level>` or `Depth:` — quick scan (5), standard (15), deep (30+)
+- `Focus:` — specific area to focus on (e.g., "authentication and authorization")
 - `Iterations:` or `--iterations N` — integer for bounded mode (CRITICAL: run exactly N iterations then stop)
 
 If `Iterations: N` or `--iterations N` is found, set `max_iterations = N`. Track `current_iteration` starting at 0. After iteration N, print final summary and STOP.

--- a/commands/autoresearch/ship.md
+++ b/commands/autoresearch/ship.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:ship
 description: Universal shipping workflow — ship code, content, marketing, sales, research, or anything through structured 8-phase workflow
-argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--checklist-only] [--iterations N]"
+argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--target <path>] [--checklist-only] [--iterations N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.
@@ -17,6 +17,7 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 - `--monitor N` — post-ship monitoring for N minutes
 - `--type <type>` — override auto-detection (code-pr, code-release, deployment, content, etc.)
 - `--checklist-only` — only generate checklist
+- `--target <path>` or `Target:` — what to ship (path, PR, artifact)
 - `Iterations:` or `--iterations N` — bounded preparation iterations (CRITICAL: run exactly N prep iterations then ship)
 
 If `Iterations: N` or `--iterations N` is found, set `max_iterations = N` for the preparation loop.

--- a/guide/README.md
+++ b/guide/README.md
@@ -4,7 +4,7 @@
 
 **By [Udit Goenka](https://udit.co)**
 
-[![Version](https://img.shields.io/badge/version-1.7.1-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.7.2-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,11 +77,11 @@ echo "  Branch:          $BRANCH"
 echo ""
 
 # --- Create release branch ---
-echo "[1/6] Creating release branch: $BRANCH"
+echo "[1/7] Creating release branch: $BRANCH"
 git checkout -b "$BRANCH"
 
 # --- Bump version in plugin.json and marketplace.json ---
-echo "[2/6] Bumping versions: $CURRENT → $VERSION"
+echo "[2/7] Bumping versions: $CURRENT → $VERSION"
 for JSON_FILE in "$PLUGIN_JSON" "$MARKETPLACE_JSON"; do
   if [[ -f "$JSON_FILE" ]]; then
     echo "    Updating $JSON_FILE"

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
-version: 1.7.1
+version: 1.7.2
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration
@@ -366,7 +366,7 @@ After the wizard completes, the user gets a ready-to-paste `/autoresearch` invoc
 
 ## When to Activate
 
-- User invokes `/autoresearch` or `/ug:autoresearch` → run the loop
+- User invokes `/autoresearch` → run the loop
 - User invokes `/autoresearch:plan` → run the planning wizard
 - User invokes `/autoresearch:security` → run the security audit
 - User says "help me set up autoresearch", "plan an autoresearch run" → run the planning wizard

--- a/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -117,9 +117,9 @@ git diff --cached --quiet
 git commit -m "experiment(<scope>): <one-sentence description of what you changed and why>"
 ```
 
-**"Nothing to commit" handling:** If `git add -A` followed by `git diff --cached --quiet` shows no changes, the modification phase produced no actual diff. This is NOT a crash — log as `status=no-op` with description of what was attempted, skip verification, and proceed to next iteration. Do NOT create an empty commit.
+**"Nothing to commit" handling:** If `git add <files>` followed by `git diff --cached --quiet` shows no changes, the modification phase produced no actual diff. This is NOT a crash — log as `status=no-op` with description of what was attempted, skip verification, and proceed to next iteration. Do NOT create an empty commit.
 
-**WARNING about `git add -A`:** This stages ALL changes in the repo, including files outside the in-scope set. Before committing, run `git diff --cached --name-only` and verify that only in-scope files are staged. If unexpected files appear, unstage them with `git reset HEAD <file>` before committing.
+**WARNING:** NEVER use `git add -A` — it stages ALL files including .env, credentials, and user's unrelated work. Always use `git add <file1> <file2> ...` with explicit file paths. After staging, verify with `git diff --cached --name-only` that only in-scope files are staged.
 
 **Commit message format:** Use conventional commit format with `experiment` type: `experiment(<scope>): <description>`. This keeps compatibility with commit-lint while clearly marking autoresearch iterations. Example: `experiment(auth): increase timeout from 5s to 30s — hypothesis: reduces flaky test failures`.
 
@@ -200,7 +200,7 @@ ELIF metric_improved AND guard_failed:
     # Rework the optimization (max 2 attempts)
     FOR attempt IN 1..2:
         Analyze guard output → rework implementation (NOT tests)
-        git add -A && git commit -m "experiment: rework — <description>"
+        git add <modified-files> && git commit -m "experiment(<scope>): rework — <description>"
         Re-run verify
         IF metric_improved:
             Re-run guard

--- a/skills/autoresearch/references/debug-workflow.md
+++ b/skills/autoresearch/references/debug-workflow.md
@@ -466,4 +466,4 @@ Iterations: 15
 Iterations: 20
 ```
 
-When `--fix` is specified, after the debug loop completes, automatically switches to `/autoresearch:fix` targeting the discovered issues.
+When `--fix` is specified, after the debug loop completes, automatically switches to `/autoresearch:fix --from-debug` targeting the discovered issues. The `--from-debug` flag tells fix to read findings from the latest debug session.

--- a/skills/autoresearch/references/fix-workflow.md
+++ b/skills/autoresearch/references/fix-workflow.md
@@ -171,7 +171,7 @@ Pick the highest-priority unfixed item and make ONE focused change.
 ## Phase 4: Commit — Before Verification
 
 ```bash
-git add -A
+git add <modified-files>
 git commit -m "fix: [what was fixed] — [file:line]"
 ```
 

--- a/skills/autoresearch/references/predict-workflow.md
+++ b/skills/autoresearch/references/predict-workflow.md
@@ -679,12 +679,12 @@ Reports older than 30 days also receive: `⚠️ Age Warning: This report is {N}
 |------|---------|---------|
 | `--scope <glob>` | Files to include in analysis | `--scope "src/api/**/*.ts"` |
 | `--goal <text>` | Focus area for all personas | `--goal "security and reliability"` |
-| `--depth <level>` | Preset (quick/standard/deep) or custom | `--depth deep` |
+| `--depth <level>` | Preset (shallow/standard/deep) | `--depth deep` |
 | `--personas <N>` | Override persona count (3-8) | `--personas 4` |
-| `--rounds <N>` | Override debate rounds (0-3) | `--rounds 1` |
+| `--rounds <N>` | Override debate rounds (1-3) | `--rounds 1` |
 | `--adversarial` | Use adversarial persona set instead of default | `--adversarial` |
 | `--chain <tools>` | Chain to downstream tool(s). Comma-separated for multi-chain | `--chain debug` or `--chain scenario,debug,fix` |
-| `--budget <dollars>` | Max LLM cost for session (default: $1.00) | `--budget 0.50` |
+| `--budget <findings>` | Max total findings across all personas (default: 40) | `--budget 20` |
 | `--fail-on <severity>` | Exit non-zero if findings at severity exist | `--fail-on critical` |
 | `--incremental` | Re-use existing knowledge files, update only changed | `--incremental` |
 
@@ -734,7 +734,7 @@ Iterations: 2
 
 # Predict → Scenario: swarm findings seed edge case exploration
 /autoresearch:predict --scope src/checkout/**/*.ts --chain scenario
-Depth: quick
+Depth: shallow
 ```
 
 ## What NOT to Do — Anti-Patterns

--- a/skills/autoresearch/references/security-workflow.md
+++ b/skills/autoresearch/references/security-workflow.md
@@ -585,7 +585,7 @@ claude -p "/autoresearch:security --fail-on critical --iterations 10"
 # Exit code 1 if any Critical findings → blocks the pipeline
 ```
 
-### `--fix` — Auto-Remediation Mode (v1.0.3)
+### `--fix` — Auto-Remediation Mode
 
 After completing the audit, switches to standard autoresearch modify→verify loop to fix confirmed findings. Uses the security audit report as its goal.
 
@@ -694,6 +694,8 @@ jobs:
         run: |
           git clone https://github.com/uditgoenka/autoresearch.git /tmp/autoresearch
           cp -r /tmp/autoresearch/skills/autoresearch .claude/skills/autoresearch
+          cp -r /tmp/autoresearch/commands/autoresearch .claude/commands/autoresearch
+          cp /tmp/autoresearch/commands/autoresearch.md .claude/commands/autoresearch.md
 
       - name: Run Security Audit
         env:


### PR DESCRIPTION
## Release v1.7.2

**Version bump:** `1.7.1` → `1.7.2`

### Summary
Comprehensive stability patch addressing 25+ bugs discovered via two rounds of deep `/autoresearch:debug --iterations 25` audits. This release focuses exclusively on fixing inconsistencies, missing flags, unsafe defaults, and documentation mismatches across all command files, workflow references, and protocol documents.

### Bug Fixes

#### Command Files
- **ship.md**: Added missing `--target <path>` flag for explicit ship target specification
- **predict.md**: Fixed `--budget` unit from dollars to findings count, matching workflow behavior
- **predict.md**: Replaced unsupported `--dry-run` with `--incremental` (done in v1.7.1, synced)
- **security.md**: Added missing `--scope`, `--depth`, and `Focus:` to argument parsing

#### Workflow References
- **debug-workflow.md**: Debug `--fix` chain now passes `--from-debug` to fix command
- **security-workflow.md**: CI template now copies `commands/` alongside `skills/` 
- **predict-workflow.md**: Fixed `--budget` docs (dollars → findings count), `--rounds` range (0-3 → 1-3), depth preset naming (quick → shallow)
- **fix-workflow.md**: Replaced all `git add -A` with `git add <modified-files>` 
- **autonomous-loop-protocol.md**: Eliminated remaining `git add -A` references, added explicit WARNING

#### SKILL.md
- Removed stale `/ug:autoresearch` alias (no backing command file)
- Bumped version to 1.7.2

#### Infrastructure
- **release.sh**: Fixed step numbering ([1/6]→[1/7], [2/6]→[2/7])
- **Distribution sync**: All root `commands/` and `skills/` updated from `.claude/` source

### Files Changed (23 files)
- `.claude/commands/autoresearch/` — predict, security, ship
- `.claude/skills/autoresearch/` — SKILL.md, all 5 workflow references
- `commands/autoresearch/` — distribution sync
- `skills/autoresearch/` — distribution sync
- `.claude-plugin/` — version bump
- `README.md`, `guide/README.md` — version badge
- `scripts/release.sh` — step numbering fix

### Checklist
- [x] plugin.json version bumped to 1.7.2
- [x] marketplace.json version bumped to 1.7.2
- [x] SKILL.md version bumped to 1.7.2
- [x] README.md version badge updated
- [x] guide/README.md version badge updated
- [x] Distribution files synced from .claude/
- [x] No sensitive files staged
- [x] All changes are bugfixes — no new features