### PR TITLE
Release v1.7.3 — Further Stability Fixes & Improvements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Claude Autoresearch — autonomous goal-directed iteration for Claude Code. Inspired by Karpathy's autoresearch: constraint + mechanical metric + autonomous iteration = compounding gains.",
   "owner": {
     "name": "Udit Goenka",
@@ -11,7 +11,7 @@
     {
       "name": "autoresearch",
       "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:predict (multi-persona swarm prediction), /autoresearch:security (STRIDE + OWASP audit), /autoresearch:ship (multi-phase delivery workflow), /autoresearch:debug (autonomous bug hunter), and /autoresearch:fix (autonomous error crusher).",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
   "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. Includes planning wizard, security audit, shipping workflow, autonomous debugger, and autonomous fixer.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"

--- a/.claude/commands/autoresearch/predict.md
+++ b/.claude/commands/autoresearch/predict.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:predict
 description: Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
-argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>]"
+argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>] [--iterations N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.
@@ -20,6 +20,9 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 - `--fail-on <severity>` — CI/CD gate
 - `--incremental` — reuse existing knowledge files, update only changed files
 - `--goal <text>` or `Goal:` — focus area for analysis
+- `Iterations:` or `--iterations N` — integer for bounded mode (CRITICAL: run exactly N iterations then stop)
+
+If `Iterations: N` or `--iterations N` is found, set `max_iterations = N`. Track `current_iteration` starting at 0. After iteration N, print final summary and STOP.
 
 All remaining text not matching flags is the goal/focus description.
 
@@ -28,6 +31,7 @@ All remaining text not matching flags is the goal/focus description.
 1. Read the predict workflow: `.claude/skills/autoresearch/references/predict-workflow.md`
 2. If scope or goal is missing — use `AskUserQuestion` with batched questions per predict-workflow.md
 3. Execute the 8-phase predict workflow
-4. If `--chain` is set, hand off to each chained command sequentially
+4. If bounded: after each iteration, check `current_iteration < max_iterations`. If not, STOP and print summary.
+5. If `--chain` is set, hand off to each chained command sequentially
 
 Stream all output live — never run in background.

--- a/.claude/commands/autoresearch/scenario.md
+++ b/.claude/commands/autoresearch/scenario.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:scenario
 description: Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
-argument-hint: "[scenario description] [--scope <glob>] [--depth shallow|standard|deep] [--domain <type>] [--iterations N]"
+argument-hint: "[scenario description] [--scope <glob>] [--depth shallow|standard|deep] [--domain <type>] [--format <type>] [--focus <area>] [--iterations N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/security.md
+++ b/.claude/commands/autoresearch/security.md
@@ -14,7 +14,7 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 - `--fix` — auto-fix confirmed Critical/High findings
 - `--fail-on <severity>` — exit non-zero for CI/CD gating (critical/high/medium)
 - `--scope <glob>` or `Scope:` — file globs to audit
-- `--depth <level>` or `Depth:` — quick scan (5), standard (15), deep (30+)
+- `--depth <level>` or `Depth:` — shallow (5 iterations), standard (15), deep (30+)
 - `Focus:` — specific area to focus on (e.g., "authentication and authorization")
 - `Iterations:` or `--iterations N` — integer for bounded mode (CRITICAL: run exactly N iterations then stop)
 

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
-version: 1.7.2
+version: 1.7.3
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -23,7 +23,7 @@ git rev-parse --git-dir 2>/dev/null || echo "FAIL: not a git repo"
 # 2. Check for dirty working tree
 git status --porcelain
 # → If dirty: warn user and ask to stash or commit first
-#   NEVER proceed with uncommitted user changes — git add -A will stage them
+#   NEVER proceed with uncommitted user changes — explicit git add will stage them
 
 # 3. Check for stale lock files
 ls .git/index.lock 2>/dev/null && echo "WARN: stale lock"

--- a/.claude/skills/autoresearch/references/predict-workflow.md
+++ b/.claude/skills/autoresearch/references/predict-workflow.md
@@ -45,7 +45,7 @@ You MUST call `AskUserQuestion` with the selected questions in ONE batched call:
 |---|--------|----------|-------------|---------|
 | 1 | `Scope` | "Which files should I analyze?" | If no `--scope` or `Scope:` provided | Suggested globs from project structure + "Entire codebase" |
 | 2 | `Goal` | "What should the swarm focus on?" | If no explicit goal inline | "Code quality & reliability", "Security vulnerabilities", "Performance bottlenecks", "Architecture review", "All of the above" |
-| 3 | `Depth` | "How deep should I analyze?" | Always | "Quick scan (3 personas, 1 round)", "Standard (5 personas, 2 rounds) — recommended", "Deep investigation (8 personas, 3 rounds)", "Custom" |
+| 3 | `Depth` | "How deep should I analyze?" | Always | "Shallow (3 personas, 1 round)", "Standard (5 personas, 2 rounds) — recommended", "Deep (8 personas, 3 rounds)", "Custom" |
 | 4 | `Chain` | "After analysis, chain to another tool?" | If no `--chain` provided | "Debug (test hypotheses)", "Security (validate vectors)", "Fix (prioritized queue)", "Ship (pre-deploy check)", "Scenario (explore edge cases)", "No chain — report only" |
 
 **IMPORTANT:** Batch ALL selected questions into a SINGLE `AskUserQuestion` call. NEVER ask one at a time — users need full context to make informed decisions together.
@@ -87,7 +87,7 @@ Parse and validate configuration:
   - `shallow` → 3 personas, 1 round
   - `standard` → 5 personas, 2 rounds (default)
   - `deep` → 8 personas, 3 rounds
-- Validate `--chain` target(s). Supports single (`--chain debug`) or comma-separated multi-chain (`--chain scenario,debug,fix`). Each target must be a known tool (debug, security, fix, ship, scenario). Multi-chain executes sequentially — each stage's findings feed into the next via handoff.json
+- Validate `--chain` target(s). Supports single (`--chain debug`) or comma-separated multi-chain (`--chain scenario,debug,fix`). **No spaces after commas** — `--chain debug,fix` not `--chain debug, fix`. Each target must be a known tool (debug, security, fix, ship, scenario). Unknown targets → error. Multi-chain executes sequentially — each stage's findings feed into the next via handoff.json. `--iterations` applies to predict only, not the chain targets
 - If `--adversarial` flag present, swap default persona set for adversarial set
 
 **Output:** `✓ Phase 1: Setup — [N] files in scope, [M] personas, [K] rounds planned`

--- a/.claude/skills/autoresearch/references/security-workflow.md
+++ b/.claude/skills/autoresearch/references/security-workflow.md
@@ -600,11 +600,11 @@ Iterations: 10
 
 1. Run the full security audit (setup + loop + report)
 2. Filter findings: only **Confirmed** severity **Critical** and **High**
-3. Switch to standard autoresearch loop:
-   - **Goal:** Fix all confirmed Critical and High findings
+3. Switch to `/autoresearch:fix` with findings context:
+   - **Target:** Re-run the security checks that found each vulnerability
    - **Scope:** Files referenced in findings (file:line locations)
-   - **Metric:** Count of remaining confirmed findings (lower is better)
-   - **Verify:** Re-run the security checks that found each vulnerability
+   - Pass the filtered findings list as context so fix knows WHAT to fix
+   - Fix picks highest-severity unfixed finding each iteration
 4. For each fix iteration:
    - Pick the highest-severity unfixed finding
    - Apply the mitigation from `recommendations.md`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) — constraint + mechanical metric + autonomous iteration = compounding gains.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
-[![Version](https://img.shields.io/badge/version-1.7.2-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.7.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
 [![Follow @iuditg](https://img.shields.io/badge/Follow-@iuditg-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/follow?screen_name=iuditg)

--- a/commands/autoresearch/predict.md
+++ b/commands/autoresearch/predict.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:predict
 description: Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
-argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>]"
+argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>] [--iterations N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.
@@ -20,6 +20,9 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 - `--fail-on <severity>` — CI/CD gate
 - `--incremental` — reuse existing knowledge files, update only changed files
 - `--goal <text>` or `Goal:` — focus area for analysis
+- `Iterations:` or `--iterations N` — integer for bounded mode (CRITICAL: run exactly N iterations then stop)
+
+If `Iterations: N` or `--iterations N` is found, set `max_iterations = N`. Track `current_iteration` starting at 0. After iteration N, print final summary and STOP.
 
 All remaining text not matching flags is the goal/focus description.
 
@@ -28,6 +31,7 @@ All remaining text not matching flags is the goal/focus description.
 1. Read the predict workflow: `.claude/skills/autoresearch/references/predict-workflow.md`
 2. If scope or goal is missing — use `AskUserQuestion` with batched questions per predict-workflow.md
 3. Execute the 8-phase predict workflow
-4. If `--chain` is set, hand off to each chained command sequentially
+4. If bounded: after each iteration, check `current_iteration < max_iterations`. If not, STOP and print summary.
+5. If `--chain` is set, hand off to each chained command sequentially
 
 Stream all output live — never run in background.

--- a/commands/autoresearch/scenario.md
+++ b/commands/autoresearch/scenario.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:scenario
 description: Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
-argument-hint: "[scenario description] [--scope <glob>] [--depth shallow|standard|deep] [--domain <type>] [--iterations N]"
+argument-hint: "[scenario description] [--scope <glob>] [--depth shallow|standard|deep] [--domain <type>] [--format <type>] [--focus <area>] [--iterations N]"
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/commands/autoresearch/security.md
+++ b/commands/autoresearch/security.md
@@ -14,7 +14,7 @@ Extract these from $ARGUMENTS — the user may provide extensive context alongsi
 - `--fix` — auto-fix confirmed Critical/High findings
 - `--fail-on <severity>` — exit non-zero for CI/CD gating (critical/high/medium)
 - `--scope <glob>` or `Scope:` — file globs to audit
-- `--depth <level>` or `Depth:` — quick scan (5), standard (15), deep (30+)
+- `--depth <level>` or `Depth:` — shallow (5 iterations), standard (15), deep (30+)
 - `Focus:` — specific area to focus on (e.g., "authentication and authorization")
 - `Iterations:` or `--iterations N` — integer for bounded mode (CRITICAL: run exactly N iterations then stop)
 

--- a/guide/README.md
+++ b/guide/README.md
@@ -4,7 +4,7 @@
 
 **By [Udit Goenka](https://udit.co)**
 
-[![Version](https://img.shields.io/badge/version-1.7.2-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.7.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,6 +66,12 @@ fi
 
 git pull origin master --quiet
 
+# Check if tag already exists
+if git tag -l "$TAG" | grep -q "$TAG"; then
+  echo "Error: Tag $TAG already exists. Choose a different version."
+  exit 1
+fi
+
 # Read current version
 CURRENT=$(grep -o '"version": "[^"]*"' "$PLUGIN_JSON" | cut -d'"' -f4)
 echo ""

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
-version: 1.7.2
+version: 1.7.3
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -23,7 +23,7 @@ git rev-parse --git-dir 2>/dev/null || echo "FAIL: not a git repo"
 # 2. Check for dirty working tree
 git status --porcelain
 # → If dirty: warn user and ask to stash or commit first
-#   NEVER proceed with uncommitted user changes — git add -A will stage them
+#   NEVER proceed with uncommitted user changes — explicit git add will stage them
 
 # 3. Check for stale lock files
 ls .git/index.lock 2>/dev/null && echo "WARN: stale lock"

--- a/skills/autoresearch/references/predict-workflow.md
+++ b/skills/autoresearch/references/predict-workflow.md
@@ -45,7 +45,7 @@ You MUST call `AskUserQuestion` with the selected questions in ONE batched call:
 |---|--------|----------|-------------|---------|
 | 1 | `Scope` | "Which files should I analyze?" | If no `--scope` or `Scope:` provided | Suggested globs from project structure + "Entire codebase" |
 | 2 | `Goal` | "What should the swarm focus on?" | If no explicit goal inline | "Code quality & reliability", "Security vulnerabilities", "Performance bottlenecks", "Architecture review", "All of the above" |
-| 3 | `Depth` | "How deep should I analyze?" | Always | "Quick scan (3 personas, 1 round)", "Standard (5 personas, 2 rounds) — recommended", "Deep investigation (8 personas, 3 rounds)", "Custom" |
+| 3 | `Depth` | "How deep should I analyze?" | Always | "Shallow (3 personas, 1 round)", "Standard (5 personas, 2 rounds) — recommended", "Deep (8 personas, 3 rounds)", "Custom" |
 | 4 | `Chain` | "After analysis, chain to another tool?" | If no `--chain` provided | "Debug (test hypotheses)", "Security (validate vectors)", "Fix (prioritized queue)", "Ship (pre-deploy check)", "Scenario (explore edge cases)", "No chain — report only" |
 
 **IMPORTANT:** Batch ALL selected questions into a SINGLE `AskUserQuestion` call. NEVER ask one at a time — users need full context to make informed decisions together.
@@ -87,7 +87,7 @@ Parse and validate configuration:
   - `shallow` → 3 personas, 1 round
   - `standard` → 5 personas, 2 rounds (default)
   - `deep` → 8 personas, 3 rounds
-- Validate `--chain` target(s). Supports single (`--chain debug`) or comma-separated multi-chain (`--chain scenario,debug,fix`). Each target must be a known tool (debug, security, fix, ship, scenario). Multi-chain executes sequentially — each stage's findings feed into the next via handoff.json
+- Validate `--chain` target(s). Supports single (`--chain debug`) or comma-separated multi-chain (`--chain scenario,debug,fix`). **No spaces after commas** — `--chain debug,fix` not `--chain debug, fix`. Each target must be a known tool (debug, security, fix, ship, scenario). Unknown targets → error. Multi-chain executes sequentially — each stage's findings feed into the next via handoff.json. `--iterations` applies to predict only, not the chain targets
 - If `--adversarial` flag present, swap default persona set for adversarial set
 
 **Output:** `✓ Phase 1: Setup — [N] files in scope, [M] personas, [K] rounds planned`

--- a/skills/autoresearch/references/security-workflow.md
+++ b/skills/autoresearch/references/security-workflow.md
@@ -600,11 +600,11 @@ Iterations: 10
 
 1. Run the full security audit (setup + loop + report)
 2. Filter findings: only **Confirmed** severity **Critical** and **High**
-3. Switch to standard autoresearch loop:
-   - **Goal:** Fix all confirmed Critical and High findings
+3. Switch to `/autoresearch:fix` with findings context:
+   - **Target:** Re-run the security checks that found each vulnerability
    - **Scope:** Files referenced in findings (file:line locations)
-   - **Metric:** Count of remaining confirmed findings (lower is better)
-   - **Verify:** Re-run the security checks that found each vulnerability
+   - Pass the filtered findings list as context so fix knows WHAT to fix
+   - Fix picks highest-severity unfixed finding each iteration
 4. For each fix iteration:
    - Pick the highest-severity unfixed finding
    - Apply the mitigation from `recommendations.md`


### PR DESCRIPTION
## Release v1.7.3

**Version bump:** `1.7.2` → `1.7.3`

### Summary
Scenario-driven stability audit (`/autoresearch:scenario --iterations 30`) identified 30 potential failure modes across all 8 subcommands. This release fixes all actionable issues — focusing on cross-command consistency, missing flags, chain handoff reliability, and release script safety.

### Bug Fixes

#### Critical — Command Trigger Failures
- **predict.md**: Added missing `--iterations N` flag support — previously silently ignored, causing bounded mode to never stop

#### High — Cross-Command Consistency
- **scenario.md**: Added `--format` and `--focus` to argument-hint — were parsed in body but unrecognized by Claude Code autocomplete
- **security.md**: Standardized depth naming from "quick scan" → "shallow" — now consistent with predict/scenario commands
- **predict-workflow.md**: Renamed interactive question "Quick scan" → "Shallow" — matches the actual flag name

#### High — Chain Handoff Reliability
- **predict-workflow.md**: Added no-space rule for `--chain` (`debug,fix` not `debug, fix`), error on unknown targets, clarified `--iterations` scope applies to predict only
- **security-workflow.md**: `--fix` chain now hands off to `/autoresearch:fix` with findings context instead of generic autoresearch loop

#### Medium — Safety & Robustness
- **release.sh**: Added preflight check for existing git tag — prevents tag collision when re-running release
- **autonomous-loop-protocol.md**: Removed last remaining `git add -A` reference (Phase 0 comment)

### Files Changed (19 files)
- `.claude/commands/autoresearch/` — predict, scenario, security
- `.claude/skills/autoresearch/` — SKILL.md, predict-workflow, security-workflow, autonomous-loop-protocol
- `.claude-plugin/` — version bumps
- `commands/`, `skills/` — distribution sync
- `scripts/release.sh` — tag existence preflight
- `README.md`, `guide/README.md` — version badges

### Checklist
- [x] plugin.json → 1.7.3
- [x] marketplace.json → 1.7.3
- [x] SKILL.md → 1.7.3
- [x] README.md badge → 1.7.3
- [x] guide/README.md badge → 1.7.3
- [x] Distribution synced
- [x] No sensitive files staged
- [x] Pure stability fixes — no new features