### PR TITLE
Fix description formatting in SKILL.md

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations; N inline config.
 version: 1.8.2
 ---
 


### PR DESCRIPTION
Using `:` is not supported in the frontmatter. Suggested to use `;` instead. Not sure about Claude, but Copolit CLI cares about it and fails to load the plugin.
GitHub itself complains about it, as can see here:
<img width="1136" height="239" alt="image" src="https://github.com/user-attachments/assets/74d7404f-9a2b-452a-956b-bc9ef8c50348" />
