### PR TITLE
fix: add session crash recovery, remove subjective simplicity override

### DIFF
--- a/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -673,8 +673,6 @@ ELIF crashed:
 - `git revert` is also safer in Claude Code — it's a non-destructive operation that doesn't trigger safety warnings.
 - Fallback: if `git revert` produces merge conflicts, use `git revert --abort` then `git reset --hard HEAD~1`.
 
-**Simplicity override:** If metric barely improved (+<0.1%) but change adds significant complexity, treat as "discard". If metric unchanged but code is simpler, treat as "keep".
-
 ## Phase 7: Log Results
 
 Append to results log (TSV format):
@@ -789,11 +787,60 @@ Set `Plateau-Patience: off` to disable plateau detection entirely and restore th
 
 ## Crash Recovery
 
+### Within an iteration (verify command failures)
+
 - Syntax error → fix immediately, don't count as separate iteration
 - Runtime error → attempt fix (max 3 tries), then move on
 - Resource exhaustion (OOM) → revert, try smaller variant
 - Infinite loop/hang → kill after timeout, revert, avoid that approach
 - External dependency failure → skip, log, try different approach
+
+### Session crash (agent itself dies mid-iteration)
+
+If the agent crashes (API timeout, context window exhaustion, user kills the process), the working tree may be in a partially modified state. On the next invocation, Phase 0 precondition checks will detect this. Here's how to recover depending on what state git is in:
+
+**Detect state:**
+
+```bash
+# 1. Uncommitted changes in working tree?
+DIRTY=$(git status --porcelain)
+
+# 2. Last commit is an unverified experiment?
+LAST_MSG=$(git log --oneline -1)
+# If it starts with "experiment(" and there's no corresponding results log entry,
+# the agent crashed after commit but before verify/decide.
+```
+
+**Recovery rules:**
+
+```
+IF working tree is dirty (changes not yet committed):
+    # Agent crashed during Phase 3 (modify) — before commit
+    # These changes were never verified. Discard them.
+    git checkout -- <in-scope files>
+    LOG "Recovered from session crash: discarded uncommitted modifications"
+    Resume loop from Phase 1
+
+IF last commit is "experiment(...)" with no matching results log entry:
+    # Agent crashed after Phase 4 (commit) but before Phase 6 (decide)
+    # The experiment was never verified. Revert it.
+    safe_revert()
+    LOG "Recovered from session crash: reverted unverified experiment"
+    Resume loop from Phase 1
+
+IF working tree is clean AND last commit has a results log entry:
+    # Agent crashed after Phase 7 (log) — clean state
+    # Nothing to recover. Resume normally.
+    Resume loop from Phase 1
+```
+
+**Phase 4 safety:** If `git commit` itself fails for any reason (disk full, hook timeout, permissions), clean up staged changes before moving on:
+
+```bash
+git reset HEAD -- .   # unstage everything
+git checkout -- <in-scope files>   # restore files to last committed state
+# Log as status=crash, continue to next iteration
+```
 
 ## Communication
 

--- a/.claude/skills/autoresearch/references/plan-workflow.md
+++ b/.claude/skills/autoresearch/references/plan-workflow.md
@@ -91,6 +91,47 @@ AskUserQuestion:
 
 If metric fails validation, explain why and suggest alternatives. **Do not proceed until metric is mechanical.**
 
+### Phase 4.1: Simplicity Check
+
+After the user picks a metric, check whether code simplicity matters for their goal. Autoresearch optimizes a single metric, so if users care about keeping code concise they need to measure it explicitly, not rely on the agent's judgment.
+
+**When the goal mentions refactoring, cleanup, reducing complexity, or simplification:** The metric should probably measure code size or complexity directly. Suggest this if the user picked a different metric:
+
+```
+AskUserQuestion:
+  question: "Your goal is about simplification, but your metric measures {metric_name}. Want to measure code size directly instead?"
+  header: "Simplicity"
+  options:
+    - label: "Yes — use line count as metric"
+      description: "Metric: total lines in scope. Verify: find {scope} -name '*.{ext}' | xargs wc -l | tail -1 | awk '{print $1}'. Guard: {test_command}"
+    - label: "Yes — use complexity as metric"
+      description: "Metric: cyclomatic complexity. Verify: {complexity_tool_command}"
+    - label: "No — keep {metric_name}"
+      description: "I care about {metric_name} more than code size"
+```
+
+**For all other goals:** Ask once whether the user wants to guard against code bloat. If yes, guide them to fold a size measurement into their verify command or set it as a guard.
+
+```
+AskUserQuestion:
+  question: "Do you want to keep code concise while optimizing? Without this, the agent may add verbose code if it improves the metric."
+  header: "Code size"
+  options:
+    - label: "No — just optimize the metric"
+      description: "The metric is all that matters (default)"
+    - label: "Yes — add a line count guard"
+      description: "Guard will fail if total lines in scope increase beyond a threshold"
+```
+
+If the user chooses the line count guard, construct a guard command that checks total lines haven't grown past a threshold (baseline + 10% is a reasonable default):
+
+```bash
+# Example guard with line-count ceiling:
+{test_command} && [ $(find {scope} -name '*.{ext}' | xargs wc -l | tail -1 | awk '{print $1}') -le {baseline_lines_plus_10pct} ]
+```
+
+**If the user says no:** Move on. The metric alone decides keep/discard.
+
 ### Phase 4.5: Define Guard (Optional)
 
 Ask if the user wants a guard command to prevent regressions:

--- a/claude-plugin/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/claude-plugin/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -673,8 +673,6 @@ ELIF crashed:
 - `git revert` is also safer in Claude Code — it's a non-destructive operation that doesn't trigger safety warnings.
 - Fallback: if `git revert` produces merge conflicts, use `git revert --abort` then `git reset --hard HEAD~1`.
 
-**Simplicity override:** If metric barely improved (+<0.1%) but change adds significant complexity, treat as "discard". If metric unchanged but code is simpler, treat as "keep".
-
 ## Phase 7: Log Results
 
 Append to results log (TSV format):
@@ -789,11 +787,60 @@ Set `Plateau-Patience: off` to disable plateau detection entirely and restore th
 
 ## Crash Recovery
 
+### Within an iteration (verify command failures)
+
 - Syntax error → fix immediately, don't count as separate iteration
 - Runtime error → attempt fix (max 3 tries), then move on
 - Resource exhaustion (OOM) → revert, try smaller variant
 - Infinite loop/hang → kill after timeout, revert, avoid that approach
 - External dependency failure → skip, log, try different approach
+
+### Session crash (agent itself dies mid-iteration)
+
+If the agent crashes (API timeout, context window exhaustion, user kills the process), the working tree may be in a partially modified state. On the next invocation, Phase 0 precondition checks will detect this. Here's how to recover depending on what state git is in:
+
+**Detect state:**
+
+```bash
+# 1. Uncommitted changes in working tree?
+DIRTY=$(git status --porcelain)
+
+# 2. Last commit is an unverified experiment?
+LAST_MSG=$(git log --oneline -1)
+# If it starts with "experiment(" and there's no corresponding results log entry,
+# the agent crashed after commit but before verify/decide.
+```
+
+**Recovery rules:**
+
+```
+IF working tree is dirty (changes not yet committed):
+    # Agent crashed during Phase 3 (modify) — before commit
+    # These changes were never verified. Discard them.
+    git checkout -- <in-scope files>
+    LOG "Recovered from session crash: discarded uncommitted modifications"
+    Resume loop from Phase 1
+
+IF last commit is "experiment(...)" with no matching results log entry:
+    # Agent crashed after Phase 4 (commit) but before Phase 6 (decide)
+    # The experiment was never verified. Revert it.
+    safe_revert()
+    LOG "Recovered from session crash: reverted unverified experiment"
+    Resume loop from Phase 1
+
+IF working tree is clean AND last commit has a results log entry:
+    # Agent crashed after Phase 7 (log) — clean state
+    # Nothing to recover. Resume normally.
+    Resume loop from Phase 1
+```
+
+**Phase 4 safety:** If `git commit` itself fails for any reason (disk full, hook timeout, permissions), clean up staged changes before moving on:
+
+```bash
+git reset HEAD -- .   # unstage everything
+git checkout -- <in-scope files>   # restore files to last committed state
+# Log as status=crash, continue to next iteration
+```
 
 ## Communication
 

--- a/claude-plugin/skills/autoresearch/references/plan-workflow.md
+++ b/claude-plugin/skills/autoresearch/references/plan-workflow.md
@@ -91,6 +91,47 @@ AskUserQuestion:
 
 If metric fails validation, explain why and suggest alternatives. **Do not proceed until metric is mechanical.**
 
+### Phase 4.1: Simplicity Check
+
+After the user picks a metric, check whether code simplicity matters for their goal. Autoresearch optimizes a single metric, so if users care about keeping code concise they need to measure it explicitly, not rely on the agent's judgment.
+
+**When the goal mentions refactoring, cleanup, reducing complexity, or simplification:** The metric should probably measure code size or complexity directly. Suggest this if the user picked a different metric:
+
+```
+AskUserQuestion:
+  question: "Your goal is about simplification, but your metric measures {metric_name}. Want to measure code size directly instead?"
+  header: "Simplicity"
+  options:
+    - label: "Yes — use line count as metric"
+      description: "Metric: total lines in scope. Verify: find {scope} -name '*.{ext}' | xargs wc -l | tail -1 | awk '{print $1}'. Guard: {test_command}"
+    - label: "Yes — use complexity as metric"
+      description: "Metric: cyclomatic complexity. Verify: {complexity_tool_command}"
+    - label: "No — keep {metric_name}"
+      description: "I care about {metric_name} more than code size"
+```
+
+**For all other goals:** Ask once whether the user wants to guard against code bloat. If yes, guide them to fold a size measurement into their verify command or set it as a guard.
+
+```
+AskUserQuestion:
+  question: "Do you want to keep code concise while optimizing? Without this, the agent may add verbose code if it improves the metric."
+  header: "Code size"
+  options:
+    - label: "No — just optimize the metric"
+      description: "The metric is all that matters (default)"
+    - label: "Yes — add a line count guard"
+      description: "Guard will fail if total lines in scope increase beyond a threshold"
+```
+
+If the user chooses the line count guard, construct a guard command that checks total lines haven't grown past a threshold (baseline + 10% is a reasonable default):
+
+```bash
+# Example guard with line-count ceiling:
+{test_command} && [ $(find {scope} -name '*.{ext}' | xargs wc -l | tail -1 | awk '{print $1}') -le {baseline_lines_plus_10pct} ]
+```
+
+**If the user says no:** Move on. The metric alone decides keep/discard.
+
 ### Phase 4.5: Define Guard (Optional)
 
 Ask if the user wants a guard command to prevent regressions:


### PR DESCRIPTION
## Summary

Two fixes to the autonomous loop protocol, bundled because they both touch Phase 6 decision logic.

### 1. Session crash recovery

The existing crash recovery handles failures during verification (OOM, syntax errors, hangs) but doesn't cover the agent itself dying mid-iteration: API timeout, context window exhaustion, user killing the process. That can leave the working tree in one of three states:

- Uncommitted edits (crashed during Phase 3 modify)
- An unverified experiment commit on HEAD (crashed after Phase 4 commit, before Phase 6 decide)
- Clean (crashed after Phase 7 log)

The protocol had no guidance for any of these. Phase 0 precondition checks now detect which state the tree is in on resume and recover: discard uncommitted edits, revert unverified experiments, or resume normally. Phase 4 also gets a safety clause that cleans up staged changes if `git commit` itself fails.

### 2. Remove subjective simplicity override, add simplicity awareness to plan wizard

Phase 6 had a one-liner: "If metric barely improved but change adds significant complexity, treat as discard. If metric unchanged but code is simpler, treat as keep." The words "significant complexity" and "simpler" are subjective. The agent applied taste, not measurement, violating the "metrics must be mechanical" principle.

Removed the override. The metric alone decides keep/discard.

To compensate, the plan wizard now has a Phase 4.1 "Simplicity Check" that asks users upfront whether they care about code size:

- If the goal involves refactoring or simplification: suggest line count or cyclomatic complexity as the primary metric, with tests as guard
- For other goals: ask if the user wants a line-count guard to prevent bloat. If yes, construct a guard with a ceiling (baseline + 10%). If no, pure metric-only decisions, no hidden tiebreakers.

Files changed:
- `autonomous-loop-protocol.md`: expanded crash recovery section, removed simplicity override from Phase 6
- `plan-workflow.md`: new Phase 4.1 simplicity check between metric definition and guard definition

## Test plan

- [ ] Kill `/autoresearch` mid-iteration (dirty working tree), restart should detect uncommitted changes, discard them, resume cleanly
- [ ] Kill `/autoresearch` after commit but before verify, restart should detect unverified experiment, revert it, resume
- [ ] `/autoresearch:plan` with goal "reduce code complexity", should suggest line count or complexity as metric
- [ ] `/autoresearch:plan` with goal "increase test coverage", should ask about code size preference and offer line-count guard
- [ ] Choose "No, just optimize the metric", should skip simplicity with no hidden tiebreakers in Phase 6
- [ ] Metric unchanged after an iteration, should discard (no simplicity override keeping it)