### PR TITLE
feat: add metric-valued guards with regression thresholds

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -580,6 +580,29 @@ Verify: npx esbuild src/index.ts --bundle --minify | wc -c
 Plateau-Patience: 20
 ```
 
+### Metric-Valued Guards
+
+By default, guards are pass/fail (exit code 0 = pass). For guards that measure a number (bundle size, response time, coverage), you can set a regression threshold instead:
+
+```
+/autoresearch
+Goal: Increase test coverage to 95%
+Verify: npx jest --coverage 2>&1 | grep 'All files' | awk '{print $4}'
+Guard: npx esbuild src/index.ts --bundle --minify | wc -c
+Guard-Direction: lower is better
+Guard-Threshold: 5%
+```
+
+This means: "optimize coverage, but reject any change that grows bundle size more than 5% from baseline." The primary metric still drives keep/discard. The guard-metric is tracked in the results log for visibility into drift over time.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `Guard` | Yes | Command that outputs a number (metric-valued) or exits 0/1 (pass/fail) |
+| `Guard-Direction` | Only for metric-valued | `higher is better` or `lower is better` |
+| `Guard-Threshold` | Only for metric-valued | Max allowed regression as % of baseline (e.g., `5%`, `0%` for strict) |
+
+Without `Guard-Direction` and `Guard-Threshold`, the guard operates in pass/fail mode.
+
 ## Setup Phase (Do Once)
 
 **If the user provides Goal, Scope, Metric, and Verify inline** → extract them and proceed to step 5.
@@ -607,6 +630,7 @@ Use a SINGLE `AskUserQuestion` call with these 4 questions:
 |---|--------|----------|---------|
 | 5 | `Verify` | "What command produces the metric? (I'll dry-run it to confirm)" | Suggested commands from detected tooling |
 | 6 | `Guard` | "Any command that must ALWAYS pass? (prevents regressions)" | "npm test", "tsc --noEmit", "npm run build", "Skip — no guard" |
+| 6b | `Guard mode` | "Pass/fail or metric-valued with threshold?" | "Pass/fail (default)", "Metric-valued with threshold" |
 | 7 | `Launch` | "Ready to go?" | "Launch (unlimited)", "Launch with iteration limit", "Edit config", "Cancel" |
 
 **After Batch 2:** Dry-run the verify command. If it fails, ask user to fix or choose a different command. If it passes, proceed with launch choice.

--- a/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -41,6 +41,16 @@ ls .pre-commit-config.yaml 2>/dev/null && echo "INFO: pre-commit framework detec
 #   treat as crash and log "hook blocked commit" — do NOT use --no-verify
 ```
 
+**If metric-valued guard is configured** (has `Guard-Direction` and `Guard-Threshold`):
+
+```bash
+# 6. Extract guard-metric baseline
+GUARD_BASELINE=$(<guard command>)
+# Validate it's a valid number (same rules as verify metric)
+# Record alongside the primary metric baseline in iteration 0
+# Track guard_best_metric = GUARD_BASELINE (updated when guard-metric improves)
+```
+
 **If any FAIL:** Stop and inform user. Do not enter the loop with broken preconditions.
 **If any WARN:** Log the warning, proceed with caution, inform user.
 
@@ -581,19 +591,50 @@ IF metric_worse AND abs(delta) < noise_floor:
 
 If a **guard** command was defined during setup, run it after verification.
 
-The guard is a command that must ALWAYS pass — it protects existing functionality while the main metric is being optimized. Common guards: `npm test`, `npm run typecheck`, `pytest`, `cargo test`.
+The guard protects existing functionality while the main metric is being optimized. It operates in one of two modes:
+
+**Pass/fail mode (default):** Guard is a command that must exit 0. Common examples: `npm test`, `npm run typecheck`, `pytest`, `cargo test`.
+
+**Metric-valued mode:** Guard extracts a number (like the verify command) and checks it against a regression threshold. Use this when you need tolerance, not a binary tripwire. Example: "bundle size can grow up to 5% from baseline, but no more."
+
+```
+# Pass/fail guard (default):
+Guard: npm test
+
+# Metric-valued guard:
+Guard: npx esbuild src/index.ts --bundle --minify | wc -c
+Guard-Direction: lower is better
+Guard-Threshold: +5%
+```
 
 **Key distinction:**
 - **Verify** answers: "Did the metric improve?" (the goal)
 - **Guard** answers: "Did anything else break?" (the safety net)
 
-**Guard rules:**
+**Guard rules (both modes):**
 - Only run if a guard was defined (it's optional)
-- Run AFTER verify — no point checking guard if the metric didn't improve
-- Guard is pass/fail only (exit code 0 = pass). No metric extraction needed
+- Run AFTER verify, no point checking guard if the metric didn't improve
 - If guard fails, revert the optimization and try to rework it (max 2 attempts)
-- NEVER modify guard/test files — always adapt the implementation instead
+- NEVER modify guard/test files, always adapt the implementation instead
 - Log guard failures distinctly so the agent can learn what kinds of changes cause regressions
+
+**Pass/fail mode rules:**
+- Exit code 0 = pass. Non-zero = fail.
+
+**Metric-valued mode rules:**
+- Extract the guard-metric using the same numeric validation as the primary metric (must match `^-?[0-9]+\.?[0-9]*$`)
+- If guard-metric extraction fails, treat as guard failure (not metric-error)
+- Compare against baseline using the threshold:
+  ```
+  IF Guard-Direction is "lower is better":
+      guard_passed = (guard_metric <= guard_baseline * (1 + threshold/100))
+      # Example: baseline 50000 bytes, threshold +5% → pass if <= 52500
+  IF Guard-Direction is "higher is better":
+      guard_passed = (guard_metric >= guard_baseline * (1 - threshold/100))
+      # Example: baseline 95% coverage, threshold +5% → pass if >= 90.25%
+  ```
+- Track `guard_best_metric`: update whenever the guard-metric improves (respecting Guard-Direction), regardless of whether the change was kept or discarded. Report in the results log for visibility into guard-metric drift.
+- `Guard-Threshold: 0%` means strict no-regression: the guard-metric must not worsen at all from baseline.
 
 **Guard failure recovery (max 2 rework attempts):**
 

--- a/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/.claude/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -673,8 +673,6 @@ ELIF crashed:
 - `git revert` is also safer in Claude Code — it's a non-destructive operation that doesn't trigger safety warnings.
 - Fallback: if `git revert` produces merge conflicts, use `git revert --abort` then `git reset --hard HEAD~1`.
 
-**Simplicity override:** If metric barely improved (+<0.1%) but change adds significant complexity, treat as "discard". If metric unchanged but code is simpler, treat as "keep".
-
 ## Phase 7: Log Results
 
 Append to results log (TSV format):
@@ -789,11 +787,60 @@ Set `Plateau-Patience: off` to disable plateau detection entirely and restore th
 
 ## Crash Recovery
 
+### Within an iteration (verify command failures)
+
 - Syntax error → fix immediately, don't count as separate iteration
 - Runtime error → attempt fix (max 3 tries), then move on
 - Resource exhaustion (OOM) → revert, try smaller variant
 - Infinite loop/hang → kill after timeout, revert, avoid that approach
 - External dependency failure → skip, log, try different approach
+
+### Session crash (agent itself dies mid-iteration)
+
+If the agent crashes (API timeout, context window exhaustion, user kills the process), the working tree may be in a partially modified state. On the next invocation, Phase 0 precondition checks will detect this. Here's how to recover depending on what state git is in:
+
+**Detect state:**
+
+```bash
+# 1. Uncommitted changes in working tree?
+DIRTY=$(git status --porcelain)
+
+# 2. Last commit is an unverified experiment?
+LAST_MSG=$(git log --oneline -1)
+# If it starts with "experiment(" and there's no corresponding results log entry,
+# the agent crashed after commit but before verify/decide.
+```
+
+**Recovery rules:**
+
+```
+IF working tree is dirty (changes not yet committed):
+    # Agent crashed during Phase 3 (modify) — before commit
+    # These changes were never verified. Discard them.
+    git checkout -- <in-scope files>
+    LOG "Recovered from session crash: discarded uncommitted modifications"
+    Resume loop from Phase 1
+
+IF last commit is "experiment(...)" with no matching results log entry:
+    # Agent crashed after Phase 4 (commit) but before Phase 6 (decide)
+    # The experiment was never verified. Revert it.
+    safe_revert()
+    LOG "Recovered from session crash: reverted unverified experiment"
+    Resume loop from Phase 1
+
+IF working tree is clean AND last commit has a results log entry:
+    # Agent crashed after Phase 7 (log) — clean state
+    # Nothing to recover. Resume normally.
+    Resume loop from Phase 1
+```
+
+**Phase 4 safety:** If `git commit` itself fails for any reason (disk full, hook timeout, permissions), clean up staged changes before moving on:
+
+```bash
+git reset HEAD -- .   # unstage everything
+git checkout -- <in-scope files>   # restore files to last committed state
+# Log as status=crash, continue to next iteration
+```
 
 ## Communication
 

--- a/.claude/skills/autoresearch/references/plan-workflow.md
+++ b/.claude/skills/autoresearch/references/plan-workflow.md
@@ -158,6 +158,65 @@ AskUserQuestion:
 
 **Guard validation:** If guard is set, run it once to confirm it passes on current codebase. If it fails, help user fix it before proceeding.
 
+### Phase 4.6: Guard Mode (if guard was set)
+
+If the user chose a guard, ask whether it's pass/fail or metric-valued:
+
+```
+AskUserQuestion:
+  question: "Should the guard just pass/fail, or do you want to track a number with a regression threshold?"
+  header: "Guard mode"
+  options:
+    - label: "Pass/fail (default)"
+      description: "Guard command must exit 0. Use for test suites, type checks, builds."
+    - label: "Metric-valued with threshold"
+      description: "Guard extracts a number. I'll ask for direction and tolerance."
+```
+
+**If metric-valued:** Collect two additional params:
+
+```
+AskUserQuestion:
+  question: "For the guard metric, is higher or lower better?"
+  header: "Guard direction"
+  options:
+    - label: "Lower is better"
+      description: "Bundle size (bytes), response time (ms), error count"
+    - label: "Higher is better"
+      description: "Coverage %, throughput, score"
+```
+
+```
+AskUserQuestion:
+  question: "How much can the guard metric regress before you want changes rejected? (as % of baseline)"
+  header: "Guard threshold"
+  options:
+    - label: "0% — strict, no regression allowed"
+      description: "Guard metric must never worsen from baseline"
+    - label: "5% — moderate tolerance (Recommended)"
+      description: "Small regressions OK if the primary metric improves"
+    - label: "10% — relaxed tolerance"
+      description: "Larger regressions tolerated"
+    - label: "Custom"
+      description: "I'll specify a percentage"
+```
+
+**Metric-valued guard validation (MANDATORY):**
+1. Run the guard command on current codebase
+2. Validate the output is a valid number (same rules as verify: must match `^-?[0-9]+\.?[0-9]*$`)
+3. Record the guard-metric baseline
+4. If extraction fails, show the error and suggest switching to pass/fail mode
+
+```
+Guard dry run:
+  Command: {guard_command}
+  Output: {raw output}
+  Extracted guard-metric: {number}
+  Guard baseline: {number}
+  Threshold: {threshold}%
+  Guard will fail if: {metric} {exceeds/drops below} {baseline * (1 +/- threshold/100)}
+```
+
 ### Phase 5: Define Direction
 
 ```

--- a/.claude/skills/autoresearch/references/plan-workflow.md
+++ b/.claude/skills/autoresearch/references/plan-workflow.md
@@ -91,6 +91,47 @@ AskUserQuestion:
 
 If metric fails validation, explain why and suggest alternatives. **Do not proceed until metric is mechanical.**
 
+### Phase 4.1: Simplicity Check
+
+After the user picks a metric, check whether code simplicity matters for their goal. Autoresearch optimizes a single metric, so if users care about keeping code concise they need to measure it explicitly, not rely on the agent's judgment.
+
+**When the goal mentions refactoring, cleanup, reducing complexity, or simplification:** The metric should probably measure code size or complexity directly. Suggest this if the user picked a different metric:
+
+```
+AskUserQuestion:
+  question: "Your goal is about simplification, but your metric measures {metric_name}. Want to measure code size directly instead?"
+  header: "Simplicity"
+  options:
+    - label: "Yes — use line count as metric"
+      description: "Metric: total lines in scope. Verify: find {scope} -name '*.{ext}' | xargs wc -l | tail -1 | awk '{print $1}'. Guard: {test_command}"
+    - label: "Yes — use complexity as metric"
+      description: "Metric: cyclomatic complexity. Verify: {complexity_tool_command}"
+    - label: "No — keep {metric_name}"
+      description: "I care about {metric_name} more than code size"
+```
+
+**For all other goals:** Ask once whether the user wants to guard against code bloat. If yes, guide them to fold a size measurement into their verify command or set it as a guard.
+
+```
+AskUserQuestion:
+  question: "Do you want to keep code concise while optimizing? Without this, the agent may add verbose code if it improves the metric."
+  header: "Code size"
+  options:
+    - label: "No — just optimize the metric"
+      description: "The metric is all that matters (default)"
+    - label: "Yes — add a line count guard"
+      description: "Guard will fail if total lines in scope increase beyond a threshold"
+```
+
+If the user chooses the line count guard, construct a guard command that checks total lines haven't grown past a threshold (baseline + 10% is a reasonable default):
+
+```bash
+# Example guard with line-count ceiling:
+{test_command} && [ $(find {scope} -name '*.{ext}' | xargs wc -l | tail -1 | awk '{print $1}') -le {baseline_lines_plus_10pct} ]
+```
+
+**If the user says no:** Move on. The metric alone decides keep/discard.
+
 ### Phase 4.5: Define Guard (Optional)
 
 Ask if the user wants a guard command to prevent regressions:

--- a/.claude/skills/autoresearch/references/results-logging.md
+++ b/.claude/skills/autoresearch/references/results-logging.md
@@ -99,7 +99,7 @@ Guard: npm run typecheck
 Create `autoresearch-results.tsv` in the working directory (gitignored):
 
 ```tsv
-iteration	commit	metric	delta	guard	status	description
+iteration	commit	metric	delta	guard	guard-metric	status	description
 ```
 
 ### Columns
@@ -111,23 +111,34 @@ iteration	commit	metric	delta	guard	status	description
 | metric | float | Measured value from verification |
 | delta | float | Change from previous best (negative = improved for "lower is better") |
 | guard | enum | `pass`, `fail`, or `-` (no guard configured) |
+| guard-metric | float or `-` | Measured guard-metric value (metric-valued guards only). `-` for pass/fail guards or no guard. |
 | status | enum | `baseline`, `keep`, `keep (reworked)`, `discard`, `crash`, `no-op`, `hook-blocked`, `metric-error` |
 | description | string | One-sentence description of what was tried |
 
-### Example
+### Example (pass/fail guard)
 
 ```tsv
-iteration	commit	metric	delta	guard	status	description
-0	a1b2c3d	85.2	0.0	pass	baseline	initial state — test coverage 85.2%
-1	b2c3d4e	87.1	+1.9	pass	keep	add tests for auth middleware edge cases
-2	-	86.5	-0.6	-	discard	refactor test helpers (broke 2 tests)
-3	-	0.0	0.0	-	crash	add integration tests (DB connection failed)
-4	-	88.9	+1.8	fail	discard	inline hot-path functions (guard: 3 tests broke)
-5	c3d4e5f	88.3	+1.2	pass	keep	add tests for error handling in API routes
-6	d4e5f6g	89.0	+0.7	pass	keep	add boundary value tests for validators
+iteration	commit	metric	delta	guard	guard-metric	status	description
+0	a1b2c3d	85.2	0.0	pass	-	baseline	initial state — test coverage 85.2%
+1	b2c3d4e	87.1	+1.9	pass	-	keep	add tests for auth middleware edge cases
+2	-	86.5	-0.6	-	-	discard	refactor test helpers (broke 2 tests)
+3	-	0.0	0.0	-	-	crash	add integration tests (DB connection failed)
+4	-	88.9	+1.8	fail	-	discard	inline hot-path functions (guard: 3 tests broke)
+5	c3d4e5f	88.3	+1.2	pass	-	keep	add tests for error handling in API routes
+6	d4e5f6g	89.0	+0.7	pass	-	keep	add boundary value tests for validators
 ```
 
-**Note:** When guard fails, the metric may have improved but the change is still discarded. The guard column makes this visible in the log so the agent can learn which optimization approaches tend to cause regressions.
+### Example (metric-valued guard — bundle size with +5% threshold)
+
+```tsv
+iteration	commit	metric	delta	guard	guard-metric	status	description
+0	a1b2c3d	85.2	0.0	pass	48200	baseline	coverage 85.2%, bundle 48200 bytes
+1	b2c3d4e	87.1	+1.9	pass	48500	keep	add auth tests (bundle +300 bytes, within 5%)
+2	-	88.0	+0.9	fail	51500	discard	add integration tests (bundle +3300, exceeds 5% of 48200)
+3	c3d4e5f	87.8	+0.7	pass	47900	keep	add unit tests (bundle decreased)
+```
+
+**Note:** When guard fails, the metric may have improved but the change is still discarded. The guard column makes this visible in the log. For metric-valued guards, the guard-metric column lets you track drift over time even when individual iterations stay within threshold.
 
 ## Log Management
 

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -580,6 +580,29 @@ Verify: npx esbuild src/index.ts --bundle --minify | wc -c
 Plateau-Patience: 20
 ```
 
+### Metric-Valued Guards
+
+By default, guards are pass/fail (exit code 0 = pass). For guards that measure a number (bundle size, response time, coverage), you can set a regression threshold instead:
+
+```
+/autoresearch
+Goal: Increase test coverage to 95%
+Verify: npx jest --coverage 2>&1 | grep 'All files' | awk '{print $4}'
+Guard: npx esbuild src/index.ts --bundle --minify | wc -c
+Guard-Direction: lower is better
+Guard-Threshold: 5%
+```
+
+This means: "optimize coverage, but reject any change that grows bundle size more than 5% from baseline." The primary metric still drives keep/discard. The guard-metric is tracked in the results log for visibility into drift over time.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `Guard` | Yes | Command that outputs a number (metric-valued) or exits 0/1 (pass/fail) |
+| `Guard-Direction` | Only for metric-valued | `higher is better` or `lower is better` |
+| `Guard-Threshold` | Only for metric-valued | Max allowed regression as % of baseline (e.g., `5%`, `0%` for strict) |
+
+Without `Guard-Direction` and `Guard-Threshold`, the guard operates in pass/fail mode.
+
 ## Setup Phase (Do Once)
 
 **If the user provides Goal, Scope, Metric, and Verify inline** → extract them and proceed to step 5.
@@ -607,6 +630,7 @@ Use a SINGLE `AskUserQuestion` call with these 4 questions:
 |---|--------|----------|---------|
 | 5 | `Verify` | "What command produces the metric? (I'll dry-run it to confirm)" | Suggested commands from detected tooling |
 | 6 | `Guard` | "Any command that must ALWAYS pass? (prevents regressions)" | "npm test", "tsc --noEmit", "npm run build", "Skip — no guard" |
+| 6b | `Guard mode` | "Pass/fail or metric-valued with threshold?" | "Pass/fail (default)", "Metric-valued with threshold" |
 | 7 | `Launch` | "Ready to go?" | "Launch (unlimited)", "Launch with iteration limit", "Edit config", "Cancel" |
 
 **After Batch 2:** Dry-run the verify command. If it fails, ask user to fix or choose a different command. If it passes, proceed with launch choice.

--- a/claude-plugin/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/claude-plugin/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -41,6 +41,16 @@ ls .pre-commit-config.yaml 2>/dev/null && echo "INFO: pre-commit framework detec
 #   treat as crash and log "hook blocked commit" — do NOT use --no-verify
 ```
 
+**If metric-valued guard is configured** (has `Guard-Direction` and `Guard-Threshold`):
+
+```bash
+# 6. Extract guard-metric baseline
+GUARD_BASELINE=$(<guard command>)
+# Validate it's a valid number (same rules as verify metric)
+# Record alongside the primary metric baseline in iteration 0
+# Track guard_best_metric = GUARD_BASELINE (updated when guard-metric improves)
+```
+
 **If any FAIL:** Stop and inform user. Do not enter the loop with broken preconditions.
 **If any WARN:** Log the warning, proceed with caution, inform user.
 
@@ -581,19 +591,50 @@ IF metric_worse AND abs(delta) < noise_floor:
 
 If a **guard** command was defined during setup, run it after verification.
 
-The guard is a command that must ALWAYS pass — it protects existing functionality while the main metric is being optimized. Common guards: `npm test`, `npm run typecheck`, `pytest`, `cargo test`.
+The guard protects existing functionality while the main metric is being optimized. It operates in one of two modes:
+
+**Pass/fail mode (default):** Guard is a command that must exit 0. Common examples: `npm test`, `npm run typecheck`, `pytest`, `cargo test`.
+
+**Metric-valued mode:** Guard extracts a number (like the verify command) and checks it against a regression threshold. Use this when you need tolerance, not a binary tripwire. Example: "bundle size can grow up to 5% from baseline, but no more."
+
+```
+# Pass/fail guard (default):
+Guard: npm test
+
+# Metric-valued guard:
+Guard: npx esbuild src/index.ts --bundle --minify | wc -c
+Guard-Direction: lower is better
+Guard-Threshold: +5%
+```
 
 **Key distinction:**
 - **Verify** answers: "Did the metric improve?" (the goal)
 - **Guard** answers: "Did anything else break?" (the safety net)
 
-**Guard rules:**
+**Guard rules (both modes):**
 - Only run if a guard was defined (it's optional)
-- Run AFTER verify — no point checking guard if the metric didn't improve
-- Guard is pass/fail only (exit code 0 = pass). No metric extraction needed
+- Run AFTER verify, no point checking guard if the metric didn't improve
 - If guard fails, revert the optimization and try to rework it (max 2 attempts)
-- NEVER modify guard/test files — always adapt the implementation instead
+- NEVER modify guard/test files, always adapt the implementation instead
 - Log guard failures distinctly so the agent can learn what kinds of changes cause regressions
+
+**Pass/fail mode rules:**
+- Exit code 0 = pass. Non-zero = fail.
+
+**Metric-valued mode rules:**
+- Extract the guard-metric using the same numeric validation as the primary metric (must match `^-?[0-9]+\.?[0-9]*$`)
+- If guard-metric extraction fails, treat as guard failure (not metric-error)
+- Compare against baseline using the threshold:
+  ```
+  IF Guard-Direction is "lower is better":
+      guard_passed = (guard_metric <= guard_baseline * (1 + threshold/100))
+      # Example: baseline 50000 bytes, threshold +5% → pass if <= 52500
+  IF Guard-Direction is "higher is better":
+      guard_passed = (guard_metric >= guard_baseline * (1 - threshold/100))
+      # Example: baseline 95% coverage, threshold +5% → pass if >= 90.25%
+  ```
+- Track `guard_best_metric`: update whenever the guard-metric improves (respecting Guard-Direction), regardless of whether the change was kept or discarded. Report in the results log for visibility into guard-metric drift.
+- `Guard-Threshold: 0%` means strict no-regression: the guard-metric must not worsen at all from baseline.
 
 **Guard failure recovery (max 2 rework attempts):**
 

--- a/claude-plugin/skills/autoresearch/references/autonomous-loop-protocol.md
+++ b/claude-plugin/skills/autoresearch/references/autonomous-loop-protocol.md
@@ -673,8 +673,6 @@ ELIF crashed:
 - `git revert` is also safer in Claude Code — it's a non-destructive operation that doesn't trigger safety warnings.
 - Fallback: if `git revert` produces merge conflicts, use `git revert --abort` then `git reset --hard HEAD~1`.
 
-**Simplicity override:** If metric barely improved (+<0.1%) but change adds significant complexity, treat as "discard". If metric unchanged but code is simpler, treat as "keep".
-
 ## Phase 7: Log Results
 
 Append to results log (TSV format):
@@ -789,11 +787,60 @@ Set `Plateau-Patience: off` to disable plateau detection entirely and restore th
 
 ## Crash Recovery
 
+### Within an iteration (verify command failures)
+
 - Syntax error → fix immediately, don't count as separate iteration
 - Runtime error → attempt fix (max 3 tries), then move on
 - Resource exhaustion (OOM) → revert, try smaller variant
 - Infinite loop/hang → kill after timeout, revert, avoid that approach
 - External dependency failure → skip, log, try different approach
+
+### Session crash (agent itself dies mid-iteration)
+
+If the agent crashes (API timeout, context window exhaustion, user kills the process), the working tree may be in a partially modified state. On the next invocation, Phase 0 precondition checks will detect this. Here's how to recover depending on what state git is in:
+
+**Detect state:**
+
+```bash
+# 1. Uncommitted changes in working tree?
+DIRTY=$(git status --porcelain)
+
+# 2. Last commit is an unverified experiment?
+LAST_MSG=$(git log --oneline -1)
+# If it starts with "experiment(" and there's no corresponding results log entry,
+# the agent crashed after commit but before verify/decide.
+```
+
+**Recovery rules:**
+
+```
+IF working tree is dirty (changes not yet committed):
+    # Agent crashed during Phase 3 (modify) — before commit
+    # These changes were never verified. Discard them.
+    git checkout -- <in-scope files>
+    LOG "Recovered from session crash: discarded uncommitted modifications"
+    Resume loop from Phase 1
+
+IF last commit is "experiment(...)" with no matching results log entry:
+    # Agent crashed after Phase 4 (commit) but before Phase 6 (decide)
+    # The experiment was never verified. Revert it.
+    safe_revert()
+    LOG "Recovered from session crash: reverted unverified experiment"
+    Resume loop from Phase 1
+
+IF working tree is clean AND last commit has a results log entry:
+    # Agent crashed after Phase 7 (log) — clean state
+    # Nothing to recover. Resume normally.
+    Resume loop from Phase 1
+```
+
+**Phase 4 safety:** If `git commit` itself fails for any reason (disk full, hook timeout, permissions), clean up staged changes before moving on:
+
+```bash
+git reset HEAD -- .   # unstage everything
+git checkout -- <in-scope files>   # restore files to last committed state
+# Log as status=crash, continue to next iteration
+```
 
 ## Communication
 

--- a/claude-plugin/skills/autoresearch/references/plan-workflow.md
+++ b/claude-plugin/skills/autoresearch/references/plan-workflow.md
@@ -158,6 +158,65 @@ AskUserQuestion:
 
 **Guard validation:** If guard is set, run it once to confirm it passes on current codebase. If it fails, help user fix it before proceeding.
 
+### Phase 4.6: Guard Mode (if guard was set)
+
+If the user chose a guard, ask whether it's pass/fail or metric-valued:
+
+```
+AskUserQuestion:
+  question: "Should the guard just pass/fail, or do you want to track a number with a regression threshold?"
+  header: "Guard mode"
+  options:
+    - label: "Pass/fail (default)"
+      description: "Guard command must exit 0. Use for test suites, type checks, builds."
+    - label: "Metric-valued with threshold"
+      description: "Guard extracts a number. I'll ask for direction and tolerance."
+```
+
+**If metric-valued:** Collect two additional params:
+
+```
+AskUserQuestion:
+  question: "For the guard metric, is higher or lower better?"
+  header: "Guard direction"
+  options:
+    - label: "Lower is better"
+      description: "Bundle size (bytes), response time (ms), error count"
+    - label: "Higher is better"
+      description: "Coverage %, throughput, score"
+```
+
+```
+AskUserQuestion:
+  question: "How much can the guard metric regress before you want changes rejected? (as % of baseline)"
+  header: "Guard threshold"
+  options:
+    - label: "0% — strict, no regression allowed"
+      description: "Guard metric must never worsen from baseline"
+    - label: "5% — moderate tolerance (Recommended)"
+      description: "Small regressions OK if the primary metric improves"
+    - label: "10% — relaxed tolerance"
+      description: "Larger regressions tolerated"
+    - label: "Custom"
+      description: "I'll specify a percentage"
+```
+
+**Metric-valued guard validation (MANDATORY):**
+1. Run the guard command on current codebase
+2. Validate the output is a valid number (same rules as verify: must match `^-?[0-9]+\.?[0-9]*$`)
+3. Record the guard-metric baseline
+4. If extraction fails, show the error and suggest switching to pass/fail mode
+
+```
+Guard dry run:
+  Command: {guard_command}
+  Output: {raw output}
+  Extracted guard-metric: {number}
+  Guard baseline: {number}
+  Threshold: {threshold}%
+  Guard will fail if: {metric} {exceeds/drops below} {baseline * (1 +/- threshold/100)}
+```
+
 ### Phase 5: Define Direction
 
 ```

--- a/claude-plugin/skills/autoresearch/references/plan-workflow.md
+++ b/claude-plugin/skills/autoresearch/references/plan-workflow.md
@@ -91,6 +91,47 @@ AskUserQuestion:
 
 If metric fails validation, explain why and suggest alternatives. **Do not proceed until metric is mechanical.**
 
+### Phase 4.1: Simplicity Check
+
+After the user picks a metric, check whether code simplicity matters for their goal. Autoresearch optimizes a single metric, so if users care about keeping code concise they need to measure it explicitly, not rely on the agent's judgment.
+
+**When the goal mentions refactoring, cleanup, reducing complexity, or simplification:** The metric should probably measure code size or complexity directly. Suggest this if the user picked a different metric:
+
+```
+AskUserQuestion:
+  question: "Your goal is about simplification, but your metric measures {metric_name}. Want to measure code size directly instead?"
+  header: "Simplicity"
+  options:
+    - label: "Yes — use line count as metric"
+      description: "Metric: total lines in scope. Verify: find {scope} -name '*.{ext}' | xargs wc -l | tail -1 | awk '{print $1}'. Guard: {test_command}"
+    - label: "Yes — use complexity as metric"
+      description: "Metric: cyclomatic complexity. Verify: {complexity_tool_command}"
+    - label: "No — keep {metric_name}"
+      description: "I care about {metric_name} more than code size"
+```
+
+**For all other goals:** Ask once whether the user wants to guard against code bloat. If yes, guide them to fold a size measurement into their verify command or set it as a guard.
+
+```
+AskUserQuestion:
+  question: "Do you want to keep code concise while optimizing? Without this, the agent may add verbose code if it improves the metric."
+  header: "Code size"
+  options:
+    - label: "No — just optimize the metric"
+      description: "The metric is all that matters (default)"
+    - label: "Yes — add a line count guard"
+      description: "Guard will fail if total lines in scope increase beyond a threshold"
+```
+
+If the user chooses the line count guard, construct a guard command that checks total lines haven't grown past a threshold (baseline + 10% is a reasonable default):
+
+```bash
+# Example guard with line-count ceiling:
+{test_command} && [ $(find {scope} -name '*.{ext}' | xargs wc -l | tail -1 | awk '{print $1}') -le {baseline_lines_plus_10pct} ]
+```
+
+**If the user says no:** Move on. The metric alone decides keep/discard.
+
 ### Phase 4.5: Define Guard (Optional)
 
 Ask if the user wants a guard command to prevent regressions:

--- a/claude-plugin/skills/autoresearch/references/results-logging.md
+++ b/claude-plugin/skills/autoresearch/references/results-logging.md
@@ -99,7 +99,7 @@ Guard: npm run typecheck
 Create `autoresearch-results.tsv` in the working directory (gitignored):
 
 ```tsv
-iteration	commit	metric	delta	guard	status	description
+iteration	commit	metric	delta	guard	guard-metric	status	description
 ```
 
 ### Columns
@@ -111,23 +111,34 @@ iteration	commit	metric	delta	guard	status	description
 | metric | float | Measured value from verification |
 | delta | float | Change from previous best (negative = improved for "lower is better") |
 | guard | enum | `pass`, `fail`, or `-` (no guard configured) |
+| guard-metric | float or `-` | Measured guard-metric value (metric-valued guards only). `-` for pass/fail guards or no guard. |
 | status | enum | `baseline`, `keep`, `keep (reworked)`, `discard`, `crash`, `no-op`, `hook-blocked`, `metric-error` |
 | description | string | One-sentence description of what was tried |
 
-### Example
+### Example (pass/fail guard)
 
 ```tsv
-iteration	commit	metric	delta	guard	status	description
-0	a1b2c3d	85.2	0.0	pass	baseline	initial state — test coverage 85.2%
-1	b2c3d4e	87.1	+1.9	pass	keep	add tests for auth middleware edge cases
-2	-	86.5	-0.6	-	discard	refactor test helpers (broke 2 tests)
-3	-	0.0	0.0	-	crash	add integration tests (DB connection failed)
-4	-	88.9	+1.8	fail	discard	inline hot-path functions (guard: 3 tests broke)
-5	c3d4e5f	88.3	+1.2	pass	keep	add tests for error handling in API routes
-6	d4e5f6g	89.0	+0.7	pass	keep	add boundary value tests for validators
+iteration	commit	metric	delta	guard	guard-metric	status	description
+0	a1b2c3d	85.2	0.0	pass	-	baseline	initial state — test coverage 85.2%
+1	b2c3d4e	87.1	+1.9	pass	-	keep	add tests for auth middleware edge cases
+2	-	86.5	-0.6	-	-	discard	refactor test helpers (broke 2 tests)
+3	-	0.0	0.0	-	-	crash	add integration tests (DB connection failed)
+4	-	88.9	+1.8	fail	-	discard	inline hot-path functions (guard: 3 tests broke)
+5	c3d4e5f	88.3	+1.2	pass	-	keep	add tests for error handling in API routes
+6	d4e5f6g	89.0	+0.7	pass	-	keep	add boundary value tests for validators
 ```
 
-**Note:** When guard fails, the metric may have improved but the change is still discarded. The guard column makes this visible in the log so the agent can learn which optimization approaches tend to cause regressions.
+### Example (metric-valued guard — bundle size with +5% threshold)
+
+```tsv
+iteration	commit	metric	delta	guard	guard-metric	status	description
+0	a1b2c3d	85.2	0.0	pass	48200	baseline	coverage 85.2%, bundle 48200 bytes
+1	b2c3d4e	87.1	+1.9	pass	48500	keep	add auth tests (bundle +300 bytes, within 5%)
+2	-	88.0	+0.9	fail	51500	discard	add integration tests (bundle +3300, exceeds 5% of 48200)
+3	c3d4e5f	87.8	+0.7	pass	47900	keep	add unit tests (bundle decreased)
+```
+
+**Note:** When guard fails, the metric may have improved but the change is still discarded. The guard column makes this visible in the log. For metric-valued guards, the guard-metric column lets you track drift over time even when individual iterations stay within threshold.
 
 ## Log Management
 


### PR DESCRIPTION
## Summary

Guards today are binary: exit code 0 passes, anything else fails. That works for test suites and type checks, but not for metrics like bundle size or response time where you need tolerance. A change that adds 50 bytes to a 48KB bundle shouldn't be treated the same as one that doubles it.

This PR adds metric-valued guards. When a guard command outputs a number, you can set a regression threshold:

```
Guard: npx esbuild src/index.ts --bundle --minify | wc -c
Guard-Direction: lower is better
Guard-Threshold: 5%
```

"Reject any change that grows bundle size more than 5% from baseline." The primary metric still drives keep/discard. The guard stays a constraint, not an optimization target.

Without `Guard-Direction` and `Guard-Threshold`, guards operate in pass/fail mode. No breaking change to existing configs.

The guard-metric value is tracked in the results log (new `guard-metric` column) along with the best value seen, so you can spot drift over time even when individual iterations stay within threshold.

Files changed:
- `autonomous-loop-protocol.md`: Phase 0 guard-metric baseline extraction, Phase 5.5 rewritten for both modes with threshold comparison logic and guard-best tracking
- `plan-workflow.md`: new Phase 4.6 collects Guard-Direction and Guard-Threshold with dry-run validation
- `results-logging.md`: added `guard-metric` column to TSV format, examples for both guard modes
- `SKILL.md`: documented Guard-Direction, Guard-Threshold params with inline config example and param table

## Test plan

- [ ] `/autoresearch` with pass/fail guard (e.g. `npm test`), behavior unchanged
- [ ] `/autoresearch` with metric-valued guard and `Guard-Threshold: 5%`, change within threshold passes, change exceeding threshold fails
- [ ] `/autoresearch` with `Guard-Threshold: 0%`, any regression fails guard
- [ ] Guard-metric extraction returns non-numeric value, treated as guard failure
- [ ] `/autoresearch:plan`, choose "Metric-valued with threshold", wizard collects direction and threshold, dry-runs the guard command
- [ ] Results log shows guard-metric values for metric-valued guard, `-` for pass/fail guard
- [ ] Guard rework logic still works: metric-valued guard failure triggers 2 rework attempts