### PR TITLE
fix: quote skill descriptions in frontmatter

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config."
 metadata:
   source: claude-port
   version: 1.9.11

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config."
 version: 1.9.11
 ---
 

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config."
 compatibility: opencode
 metadata:
   source: claude-port

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config."
 version: 1.9.0
 ---
 


### PR DESCRIPTION
## Summary
- quote the `description` frontmatter in all distributed `autoresearch` skill files
- fix a Codex skill loading issue I hit while installing and running the skill locally
- apply the same change to Claude Code and OpenCode skill files as well, since they may be affected by the same frontmatter parsing behavior

## Root Cause
While installing and running this skill in Codex, the skill failed to load because the unquoted `description` frontmatter was parsed incorrectly. Wrapping the value in quotes keeps the long description as a single YAML string.

I have not confirmed whether Claude Code or OpenCode are affected by the exact same parser behavior, but I assumed the same risk applies and updated all corresponding skill files for consistency.

## Files Changed
- `.claude/skills/autoresearch/SKILL.md`
- `.opencode/skills/autoresearch/SKILL.md`
- `.agents/skills/autoresearch/SKILL.md`
- `claude-plugin/skills/autoresearch/SKILL.md`

## How to Test
1. Install or load the skill in Codex.
2. Verify the `autoresearch` skill now loads successfully.
3. Confirm the frontmatter `description` value is read as a valid YAML string in all updated skill files.

## Validation
- parsed the frontmatter of all updated files as YAML and confirmed `description` loads as a string
