### PR TITLE
Fix invalid YAML frontmatter in autoresearch skill files

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config."
 metadata:
   source: claude-port
   version: 1.9.11

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config."
 version: 1.9.11
 ---
 

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config."
 compatibility: opencode
 metadata:
   source: claude-port

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config."
 version: 1.9.0
 ---
 


### PR DESCRIPTION
## Summary
This quotes the `description` field in all distributed `autoresearch` `SKILL.md` files so their YAML frontmatter parses correctly.

## What changed
- Quoted the `description` value in `.agents/skills/autoresearch/SKILL.md`
- Quoted the `description` value in `.claude/skills/autoresearch/SKILL.md`
- Quoted the `description` value in `.opencode/skills/autoresearch/SKILL.md`
- Quoted the `description` value in `claude-plugin/skills/autoresearch/SKILL.md`

## Why
The previous frontmatter included `Iterations: N` inside an unquoted scalar. YAML parsers treat the colon as a mapping separator, which makes the frontmatter invalid and can prevent the skill from being loaded.

## Validation
- Parsed the frontmatter from all four files with `yaml.safe_load(...)`
- Confirmed all four files now parse successfully

Fixes #69