### PR TITLE
Fix: /autoresearch skill reliably triggers on all subcommands (v1.9.12)

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: Use when user types /autoresearch, $autoresearch plan, $autoresearch debug, $autoresearch fix, $autoresearch security, $autoresearch ship, $autoresearch scenario, $autoresearch predict, $autoresearch learn, or $autoresearch reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
 metadata:
   source: claude-port
-  version: 1.9.11
+  version: 1.9.12
   short-description: Autonomous goal-directed iteration engine
 ---
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "1.9.0",
+  "version": "1.9.12",
   "description": "Claude Autoresearch \u2014 autonomous goal-directed iteration for Claude Code. Inspired by Karpathy's autoresearch: constraint + mechanical metric + autonomous iteration = compounding gains.",
   "owner": {
     "name": "Udit Goenka",
@@ -11,7 +11,7 @@
     {
       "name": "autoresearch",
       "description": "Autonomous improvement engine: /autoresearch runs an unlimited modify-verify-keep/discard loop. Includes /autoresearch:plan (goal wizard), /autoresearch:predict (multi-persona swarm prediction), /autoresearch:reason (adversarial refinement for subjective domains), /autoresearch:security (STRIDE + OWASP audit), /autoresearch:ship (multi-phase delivery workflow), /autoresearch:debug (autonomous bug hunter), /autoresearch:fix (autonomous error crusher), /autoresearch:scenario (edge case explorer), and /autoresearch:learn (autonomous documentation engine).",
-      "version": "1.9.0",
+      "version": "1.9.12",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"

--- a/.claude/commands/autoresearch.md
+++ b/.claude/commands/autoresearch.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
+description: Use when user types /autoresearch or asks to run an autonomous iteration loop against a goal/metric. Autonomous Goal-directed Iteration — modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
 argument-hint: "[Goal: <text>] [Scope: <glob>] [Metric: <text>] [Verify: <cmd>] [Guard: <cmd>] [--iterations N]"
 ---
 

--- a/.claude/commands/autoresearch/debug.md
+++ b/.claude/commands/autoresearch/debug.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:debug
-description: Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
+description: Use when user types /autoresearch:debug or asks to hunt bugs / find root cause iteratively. Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
 argument-hint: "[--fix] [--scope <glob>] [--symptom <text>] [--severity <level>] [--technique <name>] [--iterations N]"
 ---
 

--- a/.claude/commands/autoresearch/fix.md
+++ b/.claude/commands/autoresearch/fix.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:fix
-description: Autonomous fix loop — iteratively repairs errors until zero remain. One fix per iteration, atomic, auto-reverted on failure.
+description: Use when user types /autoresearch:fix or asks to repair errors iteratively until zero remain. Autonomous fix loop — one fix per iteration, atomic, auto-reverted on failure.
 argument-hint: "[--target <cmd>] [--guard <cmd>] [--scope <glob>] [--category <type>] [--skip-lint] [--from-debug] [--iterations N]"
 ---
 

--- a/.claude/commands/autoresearch/learn.md
+++ b/.claude/commands/autoresearch/learn.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:learn
-description: Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop
+description: Use when user types /autoresearch:learn or asks to document/learn the codebase. Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop.
 argument-hint: "[goal/focus] [--mode init|update|check|summarize] [--scope <glob>] [--depth quick|standard|deep] [--file <name>] [--scan] [--topics <list>] [--no-fix] [--format markdown|html|json|rst] [--iterations N]"
 ---
 

--- a/.claude/commands/autoresearch/plan.md
+++ b/.claude/commands/autoresearch/plan.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:plan
-description: Interactive wizard to build Scope, Metric, Direction & Verify from a Goal
+description: Use when user types /autoresearch:plan or asks to turn a goal into Scope/Metric/Direction/Verify. Interactive wizard that builds the full autoresearch config from a single Goal.
 argument-hint: "[goal description]"
 ---
 

--- a/.claude/commands/autoresearch/predict.md
+++ b/.claude/commands/autoresearch/predict.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:predict
-description: Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
+description: Use when user types /autoresearch:predict or asks for multi-persona pre-analysis. Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
 argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>] [--iterations N]"
 ---
 

--- a/.claude/commands/autoresearch/reason.md
+++ b/.claude/commands/autoresearch/reason.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:reason
-description: Isolated multi-agent adversarial refinement — generate, critique, synthesize, and judge outputs through repeated rounds until convergence. Produces a lineage of evolving candidates with documented decision rationale. Zero external dependencies.
+description: Use when user types /autoresearch:reason or asks for adversarial generate-critique-synthesize refinement. Isolated multi-agent adversarial refinement — generate, critique, synthesize, and judge outputs through repeated rounds until convergence. Produces a lineage of evolving candidates with documented decision rationale.
 argument-hint: "[task/question] [--domain <domain>] [--mode convergent|creative|debate] [--judges N] [--iterations N] [--convergence N] [--chain debug|plan|fix|scenario|predict|ship|learn]"
 ---
 

--- a/.claude/commands/autoresearch/scenario.md
+++ b/.claude/commands/autoresearch/scenario.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:scenario
-description: Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
+description: Use when user types /autoresearch:scenario or asks to explore edge cases from a seed scenario. Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
 argument-hint: "[scenario description] [--scope <glob>] [--depth shallow|standard|deep] [--domain <type>] [--format <type>] [--focus <area>] [--iterations N]"
 ---
 

--- a/.claude/commands/autoresearch/security.md
+++ b/.claude/commands/autoresearch/security.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:security
-description: Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas
+description: Use when user types /autoresearch:security or asks for STRIDE / OWASP / red-team audit. Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas.
 argument-hint: "[--diff] [--fix] [--fail-on <severity>] [--scope <glob>] [--depth <level>] [--iterations N]"
 ---
 

--- a/.claude/commands/autoresearch/ship.md
+++ b/.claude/commands/autoresearch/ship.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:ship
-description: Universal shipping workflow — ship code, content, marketing, sales, research, or anything through structured 8-phase workflow
+description: Use when user types /autoresearch:ship or asks to run the 8-phase ship/deliver workflow. Universal shipping workflow — ship code, content, marketing, sales, research, or anything through a structured 8-phase workflow.
 argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--target <path>] [--checklist-only] [--iterations N]"
 ---
 

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
-version: 1.9.11
+description: Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+version: 1.9.12
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/.opencode/commands/autoresearch.md
+++ b/.opencode/commands/autoresearch.md
@@ -1,5 +1,5 @@
 ---
-description: Autonomous Goal-directed Iteration. Modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
+description: Use when user types /autoresearch or asks to run an autonomous iteration loop against a goal/metric. Autonomous Goal-directed Iteration — modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_debug.md
+++ b/.opencode/commands/autoresearch_debug.md
@@ -1,5 +1,5 @@
 ---
-description: Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
+description: Use when user types /autoresearch_debug or asks to hunt bugs / find root cause iteratively. Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_fix.md
+++ b/.opencode/commands/autoresearch_fix.md
@@ -1,5 +1,5 @@
 ---
-description: Autonomous fix loop — iteratively repairs errors until zero remain. One fix per iteration, atomic, auto-reverted on failure.
+description: Use when user types /autoresearch_fix or asks to repair errors iteratively until zero remain. Autonomous fix loop — one fix per iteration, atomic, auto-reverted on failure.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_learn.md
+++ b/.opencode/commands/autoresearch_learn.md
@@ -1,5 +1,5 @@
 ---
-description: Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop
+description: Use when user types /autoresearch_learn or asks to document/learn the codebase. Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_plan.md
+++ b/.opencode/commands/autoresearch_plan.md
@@ -1,5 +1,5 @@
 ---
-description: Interactive wizard to build Scope, Metric, Direction & Verify from a Goal
+description: Use when user types /autoresearch_plan or asks to turn a goal into Scope/Metric/Direction/Verify. Interactive wizard that builds the full autoresearch config from a single Goal.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_predict.md
+++ b/.opencode/commands/autoresearch_predict.md
@@ -1,5 +1,5 @@
 ---
-description: Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
+description: Use when user types /autoresearch_predict or asks for multi-persona pre-analysis. Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_reason.md
+++ b/.opencode/commands/autoresearch_reason.md
@@ -1,5 +1,5 @@
 ---
-description: Isolated multi-agent adversarial refinement — generate, critique, synthesize, repeat until convergence.
+description: Use when user types /autoresearch_reason or asks for adversarial generate-critique-synthesize refinement. Isolated multi-agent adversarial refinement — generate, critique, synthesize, repeat until convergence.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_scenario.md
+++ b/.opencode/commands/autoresearch_scenario.md
@@ -1,5 +1,5 @@
 ---
-description: Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
+description: Use when user types /autoresearch_scenario or asks to explore edge cases from a seed scenario. Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_security.md
+++ b/.opencode/commands/autoresearch_security.md
@@ -1,5 +1,5 @@
 ---
-description: Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas
+description: Use when user types /autoresearch_security or asks for STRIDE / OWASP / red-team audit. Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas.
 agent: build
 ---
 

--- a/.opencode/commands/autoresearch_ship.md
+++ b/.opencode/commands/autoresearch_ship.md
@@ -1,5 +1,5 @@
 ---
-description: Universal shipping workflow — ship code, content, marketing, sales, research, or anything through structured 8-phase workflow
+description: Use when user types /autoresearch_ship or asks to run the 8-phase ship/deliver workflow. Universal shipping workflow — ship code, content, marketing, sales, research, or anything through a structured 8-phase workflow.
 agent: build
 ---
 

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
+description: Use when user types /autoresearch, /autoresearch_plan, /autoresearch_debug, /autoresearch_fix, /autoresearch_security, /autoresearch_ship, /autoresearch_scenario, /autoresearch_predict, /autoresearch_learn, or /autoresearch_reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
 compatibility: opencode
 metadata:
   source: claude-port
-  version: 1.9.11
+  version: 1.9.12
 ---
 
 # OpenCode Autoresearch — Autonomous Goal-directed Iteration

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
   "description": "Autonomous improvement engine for Claude Code. Runs an unbounded modify-verify-keep/discard loop against any mechanical metric. 10 subcommands: plan, debug, fix, security, ship, scenario, predict, learn, and reason.",
-  "version": "1.9.0",
+  "version": "1.9.12",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"

--- a/claude-plugin/commands/autoresearch.md
+++ b/claude-plugin/commands/autoresearch.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
+description: Use when user types /autoresearch or asks to run an autonomous iteration loop against a goal/metric. Autonomous Goal-directed Iteration — modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
 argument-hint: "[Goal: <text>] [Scope: <glob>] [Metric: <text>] [Verify: <cmd>] [Guard: <cmd>] [--iterations N]"
 ---
 

--- a/claude-plugin/commands/autoresearch/debug.md
+++ b/claude-plugin/commands/autoresearch/debug.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:debug
-description: Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
+description: Use when user types /autoresearch:debug or asks to hunt bugs / find root cause iteratively. Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
 argument-hint: "[--fix] [--scope <glob>] [--symptom <text>] [--severity <level>] [--technique <name>] [--iterations N]"
 ---
 

--- a/claude-plugin/commands/autoresearch/fix.md
+++ b/claude-plugin/commands/autoresearch/fix.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:fix
-description: Autonomous fix loop — iteratively repairs errors until zero remain. One fix per iteration, atomic, auto-reverted on failure.
+description: Use when user types /autoresearch:fix or asks to repair errors iteratively until zero remain. Autonomous fix loop — one fix per iteration, atomic, auto-reverted on failure.
 argument-hint: "[--target <cmd>] [--guard <cmd>] [--scope <glob>] [--category <type>] [--skip-lint] [--from-debug] [--iterations N]"
 ---
 

--- a/claude-plugin/commands/autoresearch/learn.md
+++ b/claude-plugin/commands/autoresearch/learn.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:learn
-description: Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop
+description: Use when user types /autoresearch:learn or asks to document/learn the codebase. Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop.
 argument-hint: "[goal/focus] [--mode init|update|check|summarize] [--scope <glob>] [--depth quick|standard|deep] [--file <name>] [--scan] [--topics <list>] [--no-fix] [--format markdown|html|json|rst] [--iterations N]"
 ---
 

--- a/claude-plugin/commands/autoresearch/plan.md
+++ b/claude-plugin/commands/autoresearch/plan.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:plan
-description: Interactive wizard to build Scope, Metric, Direction & Verify from a Goal
+description: Use when user types /autoresearch:plan or asks to turn a goal into Scope/Metric/Direction/Verify. Interactive wizard that builds the full autoresearch config from a single Goal.
 argument-hint: "[goal description]"
 ---
 

--- a/claude-plugin/commands/autoresearch/predict.md
+++ b/claude-plugin/commands/autoresearch/predict.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:predict
-description: Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
+description: Use when user types /autoresearch:predict or asks for multi-persona pre-analysis. Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
 argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>] [--iterations N]"
 ---
 

--- a/claude-plugin/commands/autoresearch/reason.md
+++ b/claude-plugin/commands/autoresearch/reason.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:reason
-description: Isolated multi-agent adversarial refinement — generate, critique, synthesize, and judge outputs through repeated rounds until convergence. Produces a lineage of evolving candidates with documented decision rationale. Zero external dependencies.
+description: Use when user types /autoresearch:reason or asks for adversarial generate-critique-synthesize refinement. Isolated multi-agent adversarial refinement — generate, critique, synthesize, and judge outputs through repeated rounds until convergence. Produces a lineage of evolving candidates with documented decision rationale.
 argument-hint: "[task/question] [--domain <domain>] [--mode convergent|creative|debate] [--judges N] [--iterations N] [--convergence N] [--chain debug|plan|fix|scenario|predict|ship|learn]"
 ---
 

--- a/claude-plugin/commands/autoresearch/scenario.md
+++ b/claude-plugin/commands/autoresearch/scenario.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:scenario
-description: Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
+description: Use when user types /autoresearch:scenario or asks to explore edge cases from a seed scenario. Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
 argument-hint: "[scenario description] [--scope <glob>] [--depth shallow|standard|deep] [--domain <type>] [--format <type>] [--focus <area>] [--iterations N]"
 ---
 

--- a/claude-plugin/commands/autoresearch/security.md
+++ b/claude-plugin/commands/autoresearch/security.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:security
-description: Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas
+description: Use when user types /autoresearch:security or asks for STRIDE / OWASP / red-team audit. Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas.
 argument-hint: "[--diff] [--fix] [--fail-on <severity>] [--scope <glob>] [--depth <level>] [--iterations N]"
 ---
 

--- a/claude-plugin/commands/autoresearch/ship.md
+++ b/claude-plugin/commands/autoresearch/ship.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch:ship
-description: Universal shipping workflow — ship code, content, marketing, sales, research, or anything through structured 8-phase workflow
+description: Use when user types /autoresearch:ship or asks to run the 8-phase ship/deliver workflow. Universal shipping workflow — ship code, content, marketing, sales, research, or anything through a structured 8-phase workflow.
 argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--target <path>] [--checklist-only] [--iterations N]"
 ---
 

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.
-version: 1.9.0
+description: Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+version: 1.9.12
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/guide/README.md
+++ b/guide/README.md
@@ -4,7 +4,7 @@
 
 **By [Udit Goenka](https://udit.co)**
 
-[![Version](https://img.shields.io/badge/version-1.9.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-1.9.12-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>


### PR DESCRIPTION
## Summary

Fixes a long-standing usability bug where `/autoresearch` and all 9 subcommands (`plan`, `debug`, `fix`, `security`, `ship`, `scenario`, `predict`, `learn`, `reason`) failed to trigger ~80% of the time — users were reporting they had to type ``STRICTLY trigger it`` 10+ times before the skill would activate.

**Version bump:** `1.9.0` → `1.9.12` (patch — pure description/metadata fix, zero behavior change).

## Root cause

Claude Code's skill dispatcher uses **description-based fuzzy matching** to decide whether to activate a skill when a user types a slash command or a natural-language ask. Until this patch, not a single description in the skill pack contained the literal slash-command token it was supposed to dispatch.

Example — the old `.claude/skills/autoresearch/SKILL.md` description:

> Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. Supports bounded iteration via Iterations: N inline config.

When the user typed `/autoresearch:debug`, the dispatcher had to infer intent from prose like _"Autonomous Goal-directed Iteration"_ — which shares zero token overlap with the literal user input `/autoresearch:debug`. That made the matcher flaky, non-deterministic, and order-sensitive with neighboring skills (`ck-autoresearch`, `ralph-loop`, etc.).

## Fix

Every skill and slash-command description now **begins with an explicit trigger sentence** that contains the exact token the user would type:

| File surface | New prefix (verbatim start of description) |
|---|---|
| `.claude/skills/autoresearch/SKILL.md` | `Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason...` |
| `.claude/commands/autoresearch.md` | `Use when user types /autoresearch or asks to run an autonomous iteration loop...` |
| `.claude/commands/autoresearch/debug.md` | `Use when user types /autoresearch:debug or asks to hunt bugs...` |
| ...and so on for all 9 subcommands | (same pattern, one per subcommand) |

Descriptions for the **OpenCode** mirrors use underscore naming (`/autoresearch_debug` etc., matching OpenCode's command syntax) and descriptions for the **Codex** skill use Codex's `$autoresearch debug` invocation form. Both were generated automatically by the existing `scripts/sync-opencode.sh` and `scripts/sync-codex.sh` pipelines.

## Scope of changes (37 files)

**Source of truth — Claude Code:**
- `.claude/skills/autoresearch/SKILL.md` (description + version)
- `.claude/commands/autoresearch.md` (description)
- `.claude/commands/autoresearch/{debug,fix,learn,plan,predict,reason,scenario,security,ship}.md` (9 files — description)

**Plugin distribution mirror (`claude-plugin/`):**
- `claude-plugin/.claude-plugin/plugin.json` (version 1.9.0 → 1.9.12)
- `claude-plugin/skills/autoresearch/SKILL.md` (description + version)
- `claude-plugin/commands/autoresearch.md` + `claude-plugin/commands/autoresearch/*.md` (10 files — description)

**Marketplace registration:**
- `.claude-plugin/marketplace.json` (top-level version + plugin entry version 1.9.0 → 1.9.12)

**OpenCode mirror (hand-maintained commands + sync-generated skill):**
- `.opencode/skills/autoresearch/SKILL.md` (regenerated via `scripts/sync-opencode.sh`)
- `.opencode/commands/autoresearch.md` + `.opencode/commands/autoresearch_{debug,fix,learn,plan,predict,reason,scenario,security,ship}.md` (10 files)

**Codex mirror:**
- `.agents/skills/autoresearch/SKILL.md` (regenerated via `scripts/sync-codex.sh`)

**Guide badge:**
- `guide/README.md` (version badge `1.9.0` → `1.9.12`)

## Validation

- [x] Every `description:` line across all 32 source/mirror files now contains a literal `/autoresearch`, `/autoresearch:<sub>`, `/autoresearch_<sub>`, or `$autoresearch <sub>` token matching the host's invocation syntax.
- [x] `scripts/sync-opencode.sh` re-ran clean (13 files updated).
- [x] `scripts/sync-codex.sh` re-ran clean (14 files updated).
- [x] Versions consistent across `.claude/skills/autoresearch/SKILL.md`, `claude-plugin/skills/autoresearch/SKILL.md`, `claude-plugin/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `guide/README.md`, `.opencode/skills/autoresearch/SKILL.md`, `.agents/skills/autoresearch/SKILL.md` — all at `1.9.12`.
- [x] Zero workflow / behavior changes — pure metadata patch.

## Test plan for reviewers

- [ ] Type `/autoresearch` in Claude Code — skill should activate on the **first** try.
- [ ] Type `/autoresearch:debug`, `/autoresearch:fix`, `/autoresearch:plan`, etc. — each subcommand should dispatch cleanly on the first try.
- [ ] Type natural language like "run autoresearch with goal: cut bundle size" — should still map to the skill.
- [ ] In OpenCode: `/autoresearch_debug` resolves first try.
- [ ] In Codex: `$autoresearch debug` resolves first try.

## Risk

Minimal. This is a description-string patch — no executable code or workflow logic touched. The only risk is if the Claude Code matcher ever over-weighted the old phrasing, but the new phrasing is strictly more informative (contains the old wording as a suffix after the trigger sentence).