### PR TITLE
fix: add missing name field to docs-manager OpenCode agent

### DIFF
--- a/.opencode/agents/docs-manager.md
+++ b/.opencode/agents/docs-manager.md
@@ -1,4 +1,5 @@
 ---
+name: docs-manager
 description: Writes and updates project documentation from structured scout reports, explicit file targets, and project context
 mode: subagent
 hidden: true


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The `.opencode/agents/docs-manager.md` frontmatter was missing the required `name` field.

## Why it matters

Without `name: docs-manager` in the frontmatter, OpenCode cannot reliably register the agent by its declared identity. The `autoresearch_learn` command spawns this agent by name — if name resolution falls back to filename inference (which varies by OpenCode version), orchestration may silently fail or produce unexpected behavior.

## Fix

Added `name: docs-manager` as the first key in the frontmatter, matching the filename and the identity used in the learn command's spawn instruction.

```diff
 ---
+name: docs-manager
 description: Writes and updates project documentation from structured scout reports, explicit file targets, and project context
 mode: subagent
```