### PR TITLE
fix: add missing name field to all 10 OpenCode commands

### DIFF
--- a/.opencode/commands/autoresearch.md
+++ b/.opencode/commands/autoresearch.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch
 description: Use when user types /autoresearch or asks to run an autonomous iteration loop against a goal/metric. Autonomous Goal-directed Iteration — modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_debug.md
+++ b/.opencode/commands/autoresearch_debug.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_debug
 description: Use when user types /autoresearch_debug or asks to hunt bugs / find root cause iteratively. Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_fix.md
+++ b/.opencode/commands/autoresearch_fix.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_fix
 description: Use when user types /autoresearch_fix or asks to repair errors iteratively until zero remain. Autonomous fix loop — one fix per iteration, atomic, auto-reverted on failure.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_learn.md
+++ b/.opencode/commands/autoresearch_learn.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_learn
 description: Use when user types /autoresearch_learn or asks to document/learn the codebase. Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_plan.md
+++ b/.opencode/commands/autoresearch_plan.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_plan
 description: Use when user types /autoresearch_plan or asks to turn a goal into Scope/Metric/Direction/Verify. Interactive wizard that builds the full autoresearch config from a single Goal.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_predict.md
+++ b/.opencode/commands/autoresearch_predict.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_predict
 description: Use when user types /autoresearch_predict or asks for multi-persona pre-analysis. Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_reason.md
+++ b/.opencode/commands/autoresearch_reason.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_reason
 description: Use when user types /autoresearch_reason or asks for adversarial generate-critique-synthesize refinement. Isolated multi-agent adversarial refinement — generate, critique, synthesize, repeat until convergence.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_scenario.md
+++ b/.opencode/commands/autoresearch_scenario.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_scenario
 description: Use when user types /autoresearch_scenario or asks to explore edge cases from a seed scenario. Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_security.md
+++ b/.opencode/commands/autoresearch_security.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_security
 description: Use when user types /autoresearch_security or asks for STRIDE / OWASP / red-team audit. Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas.
 agent: build
 ---

--- a/.opencode/commands/autoresearch_ship.md
+++ b/.opencode/commands/autoresearch_ship.md
@@ -1,4 +1,5 @@
 ---
+name: autoresearch_ship
 description: Use when user types /autoresearch_ship or asks to run the 8-phase ship/deliver workflow. Universal shipping workflow — ship code, content, marketing, sales, research, or anything through a structured 8-phase workflow.
 agent: build
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All 10 `.opencode/commands/*.md` files are missing the `name` frontmatter field.

## Why it matters

OpenCode's command schema expects an explicit `name` field for reliable registration. While OpenCode infers names from filenames as a fallback, relying on inference means:

1. Commands are not schema-compliant and may behave differently across OpenCode versions
2. `autoresearch_learn` spawns `docs-manager` by name — if name resolution is inconsistent, so is everything built on top of it

## Fix

Added `name:` to the frontmatter of all 10 commands, matching each file's basename:

| File | Added name |
|------|-----------|
| `autoresearch.md` | `autoresearch` |
| `autoresearch_debug.md` | `autoresearch_debug` |
| `autoresearch_fix.md` | `autoresearch_fix` |
| `autoresearch_learn.md` | `autoresearch_learn` |
| `autoresearch_plan.md` | `autoresearch_plan` |
| `autoresearch_predict.md` | `autoresearch_predict` |
| `autoresearch_reason.md` | `autoresearch_reason` |
| `autoresearch_scenario.md` | `autoresearch_scenario` |
| `autoresearch_security.md` | `autoresearch_security` |
| `autoresearch_ship.md` | `autoresearch_ship` |

Each insertion is a single line added as the first key in the frontmatter block, with no other changes.