### PR TITLE
fix: add allowed-tools declaration to all 20 Claude commands

### DIFF
--- a/.claude/commands/autoresearch.md
+++ b/.claude/commands/autoresearch.md
@@ -2,6 +2,7 @@
 name: autoresearch
 description: Use when user types /autoresearch or asks to run an autonomous iteration loop against a goal/metric. Autonomous Goal-directed Iteration — modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
 argument-hint: "[Goal: <text>] [Scope: <glob>] [Metric: <text>] [Verify: <cmd>] [Guard: <cmd>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/debug.md
+++ b/.claude/commands/autoresearch/debug.md
@@ -2,6 +2,7 @@
 name: autoresearch:debug
 description: Use when user types /autoresearch:debug or asks to hunt bugs / find root cause iteratively. Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
 argument-hint: "[--fix] [--scope <glob>] [--symptom <text>] [--severity <level>] [--technique <name>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/fix.md
+++ b/.claude/commands/autoresearch/fix.md
@@ -2,6 +2,7 @@
 name: autoresearch:fix
 description: Use when user types /autoresearch:fix or asks to repair errors iteratively until zero remain. Autonomous fix loop — one fix per iteration, atomic, auto-reverted on failure.
 argument-hint: "[--target <cmd>] [--guard <cmd>] [--scope <glob>] [--category <type>] [--skip-lint] [--from-debug] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/learn.md
+++ b/.claude/commands/autoresearch/learn.md
@@ -2,6 +2,7 @@
 name: autoresearch:learn
 description: Use when user types /autoresearch:learn or asks to document/learn the codebase. Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop.
 argument-hint: "[goal/focus] [--mode init|update|check|summarize] [--scope <glob>] [--depth quick|standard|deep] [--file <name>] [--scan] [--topics <list>] [--no-fix] [--format markdown|html|json|rst] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/plan.md
+++ b/.claude/commands/autoresearch/plan.md
@@ -2,6 +2,7 @@
 name: autoresearch:plan
 description: Use when user types /autoresearch:plan or asks to turn a goal into Scope/Metric/Direction/Verify. Interactive wizard that builds the full autoresearch config from a single Goal.
 argument-hint: "[goal description]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/predict.md
+++ b/.claude/commands/autoresearch/predict.md
@@ -2,6 +2,7 @@
 name: autoresearch:predict
 description: Use when user types /autoresearch:predict or asks for multi-persona pre-analysis. Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
 argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/reason.md
+++ b/.claude/commands/autoresearch/reason.md
@@ -2,6 +2,7 @@
 name: autoresearch:reason
 description: Use when user types /autoresearch:reason or asks for adversarial generate-critique-synthesize refinement. Isolated multi-agent adversarial refinement — generate, critique, synthesize, and judge outputs through repeated rounds until convergence. Produces a lineage of evolving candidates with documented decision rationale.
 argument-hint: "[task/question] [--domain <domain>] [--mode convergent|creative|debate] [--judges N] [--iterations N] [--convergence N] [--chain debug|plan|fix|scenario|predict|ship|learn]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/scenario.md
+++ b/.claude/commands/autoresearch/scenario.md
@@ -2,6 +2,7 @@
 name: autoresearch:scenario
 description: Use when user types /autoresearch:scenario or asks to explore edge cases from a seed scenario. Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
 argument-hint: "[scenario description] [--scope <glob>] [--depth shallow|standard|deep] [--domain <type>] [--format <type>] [--focus <area>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/security.md
+++ b/.claude/commands/autoresearch/security.md
@@ -2,6 +2,7 @@
 name: autoresearch:security
 description: Use when user types /autoresearch:security or asks for STRIDE / OWASP / red-team audit. Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas.
 argument-hint: "[--diff] [--fix] [--fail-on <severity>] [--scope <glob>] [--depth <level>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/.claude/commands/autoresearch/ship.md
+++ b/.claude/commands/autoresearch/ship.md
@@ -2,6 +2,7 @@
 name: autoresearch:ship
 description: Use when user types /autoresearch:ship or asks to run the 8-phase ship/deliver workflow. Universal shipping workflow — ship code, content, marketing, sales, research, or anything through a structured 8-phase workflow.
 argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--target <path>] [--checklist-only] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch.md
+++ b/claude-plugin/commands/autoresearch.md
@@ -2,6 +2,7 @@
 name: autoresearch
 description: Use when user types /autoresearch or asks to run an autonomous iteration loop against a goal/metric. Autonomous Goal-directed Iteration — modify, verify, keep/discard, repeat. Apply to ANY task with a measurable metric.
 argument-hint: "[Goal: <text>] [Scope: <glob>] [Metric: <text>] [Verify: <cmd>] [Guard: <cmd>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/debug.md
+++ b/claude-plugin/commands/autoresearch/debug.md
@@ -2,6 +2,7 @@
 name: autoresearch:debug
 description: Use when user types /autoresearch:debug or asks to hunt bugs / find root cause iteratively. Autonomous bug-hunting loop — scientific method + autoresearch iteration. Finds ALL bugs, not just one.
 argument-hint: "[--fix] [--scope <glob>] [--symptom <text>] [--severity <level>] [--technique <name>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/fix.md
+++ b/claude-plugin/commands/autoresearch/fix.md
@@ -2,6 +2,7 @@
 name: autoresearch:fix
 description: Use when user types /autoresearch:fix or asks to repair errors iteratively until zero remain. Autonomous fix loop — one fix per iteration, atomic, auto-reverted on failure.
 argument-hint: "[--target <cmd>] [--guard <cmd>] [--scope <glob>] [--category <type>] [--skip-lint] [--from-debug] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/learn.md
+++ b/claude-plugin/commands/autoresearch/learn.md
@@ -2,6 +2,7 @@
 name: autoresearch:learn
 description: Use when user types /autoresearch:learn or asks to document/learn the codebase. Autonomous codebase documentation engine — scout, learn, generate/update docs with validation-fix loop.
 argument-hint: "[goal/focus] [--mode init|update|check|summarize] [--scope <glob>] [--depth quick|standard|deep] [--file <name>] [--scan] [--topics <list>] [--no-fix] [--format markdown|html|json|rst] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/plan.md
+++ b/claude-plugin/commands/autoresearch/plan.md
@@ -2,6 +2,7 @@
 name: autoresearch:plan
 description: Use when user types /autoresearch:plan or asks to turn a goal into Scope/Metric/Direction/Verify. Interactive wizard that builds the full autoresearch config from a single Goal.
 argument-hint: "[goal description]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/predict.md
+++ b/claude-plugin/commands/autoresearch/predict.md
@@ -2,6 +2,7 @@
 name: autoresearch:predict
 description: Use when user types /autoresearch:predict or asks for multi-persona pre-analysis. Multi-persona swarm prediction — pre-analyze code from multiple expert perspectives using file-based knowledge representation. Zero external dependencies.
 argument-hint: "[goal/focus] [--scope <glob>] [--chain debug|security|fix|ship|scenario] [--depth shallow|standard|deep] [--personas N] [--rounds N] [--adversarial] [--budget <N>] [--fail-on <severity>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/reason.md
+++ b/claude-plugin/commands/autoresearch/reason.md
@@ -2,6 +2,7 @@
 name: autoresearch:reason
 description: Use when user types /autoresearch:reason or asks for adversarial generate-critique-synthesize refinement. Isolated multi-agent adversarial refinement — generate, critique, synthesize, and judge outputs through repeated rounds until convergence. Produces a lineage of evolving candidates with documented decision rationale.
 argument-hint: "[task/question] [--domain <domain>] [--mode convergent|creative|debate] [--judges N] [--iterations N] [--convergence N] [--chain debug|plan|fix|scenario|predict|ship|learn]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/scenario.md
+++ b/claude-plugin/commands/autoresearch/scenario.md
@@ -2,6 +2,7 @@
 name: autoresearch:scenario
 description: Use when user types /autoresearch:scenario or asks to explore edge cases from a seed scenario. Scenario-driven use case generator — explores situations, edge cases, and derivative scenarios from a seed scenario using autonomous iteration.
 argument-hint: "[scenario description] [--scope <glob>] [--depth shallow|standard|deep] [--domain <type>] [--format <type>] [--focus <area>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/security.md
+++ b/claude-plugin/commands/autoresearch/security.md
@@ -2,6 +2,7 @@
 name: autoresearch:security
 description: Use when user types /autoresearch:security or asks for STRIDE / OWASP / red-team audit. Autonomous security audit — STRIDE threat model + OWASP Top 10 + red-team with 4 adversarial personas.
 argument-hint: "[--diff] [--fix] [--fail-on <severity>] [--scope <glob>] [--depth <level>] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.

--- a/claude-plugin/commands/autoresearch/ship.md
+++ b/claude-plugin/commands/autoresearch/ship.md
@@ -2,6 +2,7 @@
 name: autoresearch:ship
 description: Use when user types /autoresearch:ship or asks to run the 8-phase ship/deliver workflow. Universal shipping workflow — ship code, content, marketing, sales, research, or anything through a structured 8-phase workflow.
 argument-hint: "[--dry-run] [--auto] [--force] [--rollback] [--monitor N] [--type <type>] [--target <path>] [--checklist-only] [--iterations N]"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
 EXECUTE IMMEDIATELY — do not deliberate, do not ask clarifying questions before reading the protocol.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All 20 `.claude/commands/` and `claude-plugin/commands/` files are missing the `allowed-tools` frontmatter declaration.

## Why it matters

Claude Code uses `allowed-tools` to determine which tools a command is permitted to access. Without this declaration, Claude Code may:
- Restrict access to `AskUserQuestion`, `Bash`, and file tools at runtime
- Prompt the user for permission on every single tool call
- Break the autonomous iteration loop that makes these commands useful

Every command body explicitly references tools by name (e.g. `"use AskUserQuestion with batched questions"`, running shell commands via `Verify:`/`Guard:`), but none declare them — creating a gap between what the commands expect and what Claude Code knows to allow.

## Fix

Added `allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]` to the frontmatter of all 20 command files, inserted after `argument-hint:` to maintain natural grouping:

| Tool | Used for |
|------|----------|
| `AskUserQuestion` | Batched setup questions when required params are missing |
| `Bash` | Running `Verify:` / `Guard:` shell commands in iteration loops |
| `Read` | Loading workflow reference files from `skills/autoresearch/references/` |
| `Glob` / `Grep` | Discovering files to analyze or fix |
| `Write` / `Edit` | Making code changes in fix, ship, learn, and main loops |

This covers both distributions (`.claude/` and `claude-plugin/`) so they stay in sync.