### PR TITLE
fix: eliminate shell variable interpolation in python3 sync scripts

### DIFF
--- a/scripts/sync-codex.sh
+++ b/scripts/sync-codex.sh
@@ -56,10 +56,14 @@ done
 adapt_file "$SRC/SKILL.md" "$DST/SKILL.md"
 
 # Patch frontmatter: remove version, add metadata block
-python3 -c "
+python3 - "$DST/SKILL.md" <<'PYEOF' 2>/dev/null || {
+  printf 'Warning: python3 frontmatter patch failed, SKILL.md may need manual review\n' >&2
+}
 import re, sys
 
-with open('$DST/SKILL.md', 'r') as f:
+skill_path = sys.argv[1]
+
+with open(skill_path, 'r') as f:
     content = f.read()
 
 # Replace Claude-specific header
@@ -74,11 +78,9 @@ content = re.sub(
     flags=re.DOTALL
 )
 
-with open('$DST/SKILL.md', 'w') as f:
+with open(skill_path, 'w') as f:
     f.write(content)
-" 2>/dev/null || {
-  printf 'Warning: python3 frontmatter patch failed, SKILL.md may need manual review\n' >&2
-}
+PYEOF
 
 printf '  synced: SKILL.md\n'
 

--- a/scripts/sync-opencode.sh
+++ b/scripts/sync-opencode.sh
@@ -50,17 +50,20 @@ done
 adapt_file "$SRC/SKILL.md" "$DST/SKILL.md"
 
 # Patch frontmatter: version → compatibility + metadata
-python3 -c "
-import sys
+python3 - "$DST/SKILL.md" <<'PYEOF' 2>/dev/null || {
+  printf 'Warning: python3 frontmatter patch failed, SKILL.md may need manual review\n' >&2
+}
+import re, sys
 
-with open('$DST/SKILL.md', 'r') as f:
+skill_path = sys.argv[1]
+
+with open(skill_path, 'r') as f:
     content = f.read()
 
 # Replace Claude-specific header
 content = content.replace('# Claude Autoresearch', '# OpenCode Autoresearch', 1)
 
 # Replace version frontmatter with OpenCode-compatible metadata
-import re
 content = re.sub(
     r'^(---\nname: autoresearch\ndescription: .*?\n)version: ([\d.]+)\n(---)',
     r'\1compatibility: opencode\nmetadata:\n  source: claude-port\n  version: \2\n\3',
@@ -69,11 +72,9 @@ content = re.sub(
     flags=re.DOTALL
 )
 
-with open('$DST/SKILL.md', 'w') as f:
+with open(skill_path, 'w') as f:
     f.write(content)
-" 2>/dev/null || {
-  printf 'Warning: python3 frontmatter patch failed, SKILL.md may need manual review\n' >&2
-}
+PYEOF
 
 printf '  synced: SKILL.md\n'
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium)

`scripts/sync-codex.sh` (line 59) and `scripts/sync-opencode.sh` (line 53) both use `python3 -c "..."` with `$DST` interpolated directly into the Python string literal:

```bash
python3 -c "
with open('$DST/SKILL.md', 'r') as f:   # $DST expands here
    ...
"
```

A repository path containing a single quote (`'`) or backslash would corrupt the inline Python code at the string boundary, causing a Python syntax error. The script silently swallows this via `2>/dev/null`, so SKILL.md would be left unpatched with no visible warning.

In practice the risk is low (the path comes from `BASH_SOURCE[0]`), but the pattern is fragile and unnecessary.

## Fix

Replaced `python3 -c "..."` with a stdin heredoc + `sys.argv[1]`:

```bash
# Before
python3 -c "
with open('$DST/SKILL.md', 'r') as f:
    ...
with open('$DST/SKILL.md', 'w') as f:
    ...
" 2>/dev/null || { ... }

# After
python3 - "$DST/SKILL.md" <<'PYEOF' 2>/dev/null || { ... }
import sys
skill_path = sys.argv[1]
with open(skill_path, 'r') as f:
    ...
with open(skill_path, 'w') as f:
    ...
PYEOF
```

The single-quoted `'PYEOF'` delimiter prevents all bash expansion inside the heredoc. The path is passed safely as a CLI argument and read via `sys.argv[1]`. The Python logic is otherwise identical.

Applied to both `sync-codex.sh` and `sync-opencode.sh`.