### PR TITLE
fix: add path safety guard to sync_dir before rm -rf

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -153,7 +153,12 @@ ensure_context() {
   fi
 }
 
-sync_dir() { rm -rf "$2"; mkdir -p "$(dirname "$2")"; cp -R "$1" "$2"; }
+sync_dir() {
+  [[ -n "$2" && "$2" =~ ^/.{3,}/.{1,}/.{1,} ]] || die "sync_dir: refusing unsafe destination path: ${2:-<empty>}"
+  rm -rf "$2"
+  mkdir -p "$(dirname "$2")"
+  cp -R "$1" "$2"
+}
 sync_file() { mkdir -p "$(dirname "$2")"; cp "$1" "$2"; }
 
 confirm_overwrite() {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low)

`scripts/install.sh` line 156 runs `rm -rf "$2"` in `sync_dir()` with no validation of the destination path:

```bash
sync_dir() { rm -rf "$2"; mkdir -p "$(dirname "$2")"; cp -R "$1" "$2"; }
```

While the path is derived from `$CONFIG_DIR` (which in turn comes from `$TOOL` and `$LOCATION` flag processing), a misconfigured or empty `CONFIG_DIR` could cause this to delete an unintended directory — including home or root-level paths.

## Fix

Added a guard that validates the destination is at least 3 directory levels deep before running `rm -rf`:

```bash
sync_dir() {
  [[ -n "$2" && "$2" =~ ^/.{3,}/.{1,}/.{1,} ]] || die "sync_dir: refusing unsafe destination path: ${2:-<empty>}"
  rm -rf "$2"
  mkdir -p "$(dirname "$2")"
  cp -R "$1" "$2"
}
```

This rejects empty strings, `/`, `/home`, and other too-shallow paths, while allowing all real install targets like `~/.claude/skills/autoresearch` and `~/.opencode/skills/autoresearch`. The check is intentionally conservative — it only validates path depth, not content, to avoid false positives with valid install paths.