### PR TITLE
fix(skills): escape colons in SKILL.md description so strict YAML parsers (Codex) load plugin

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autoresearch
-description: Use when user types /autoresearch, $autoresearch plan, $autoresearch debug, $autoresearch fix, $autoresearch security, $autoresearch ship, $autoresearch scenario, $autoresearch predict, $autoresearch learn, or $autoresearch reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+description: >-
+  Use when user types /autoresearch, $autoresearch plan, $autoresearch debug, $autoresearch fix, $autoresearch security, $autoresearch ship, $autoresearch scenario, $autoresearch predict, $autoresearch learn, or $autoresearch reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task; modify, verify, keep/discard, repeat. Supports bounded mode via inline Iterations N config.
 metadata:
   source: claude-port
   version: 1.9.12

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autoresearch
-description: Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+description: >-
+  Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task; modify, verify, keep/discard, repeat. Supports bounded mode via inline Iterations N config.
 version: 1.9.12
 ---
 

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autoresearch
-description: Use when user types /autoresearch, /autoresearch_plan, /autoresearch_debug, /autoresearch_fix, /autoresearch_security, /autoresearch_ship, /autoresearch_scenario, /autoresearch_predict, /autoresearch_learn, or /autoresearch_reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+description: >-
+  Use when user types /autoresearch, /autoresearch_plan, /autoresearch_debug, /autoresearch_fix, /autoresearch_security, /autoresearch_ship, /autoresearch_scenario, /autoresearch_predict, /autoresearch_learn, or /autoresearch_reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task; modify, verify, keep/discard, repeat. Supports bounded mode via inline Iterations N config.
 compatibility: opencode
 metadata:
   source: claude-port

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autoresearch
-description: Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+description: >-
+  Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task; modify, verify, keep/discard, repeat. Supports bounded mode via inline Iterations N config.
 version: 1.9.12
 ---
 


### PR DESCRIPTION
## Problem

Codex CLI fails to load the autoresearch plugin with:

```
Skipped loading 1 skill(s) due to invalid SKILL.md files.
.../skills/autoresearch/SKILL.md: invalid YAML: mapping values are not allowed in this context at line 2 column 382
```

The `description` field in all four SKILL.md variants (`claude-plugin/`, `.claude/`, `.opencode/`, `.agents/`) is an unquoted scalar containing colon-space sequences:

- `... to ANY task: modify, verify ...`
- `... bounded mode via Iterations: N inline config.`

YAML treats `: ` as a mapping indicator inside an unquoted scalar, breaking strict parsers (Codex CLI's parser is strict; Claude Code's is lenient and tolerates it, which masked the bug).

## Fix

Wrap each `description` in a folded block scalar (`>-`) and rephrase to remove the remaining `: ` patterns. No semantic change to the description, full readability preserved.

## Verification

```bash
python3 -c "import yaml; yaml.safe_load(open('claude-plugin/skills/autoresearch/SKILL.md').read().split('---',2)[1])"
# OK on all 4 SKILL.md
```

Codex CLI now loads the plugin without warnings; Claude Code load is unaffected.