### PR TITLE
fix: make skill frontmatter valid YAML

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: autoresearch
-description: Use when user types /autoresearch, $autoresearch plan, $autoresearch debug, $autoresearch fix, $autoresearch security, $autoresearch ship, $autoresearch scenario, $autoresearch predict, $autoresearch learn, or $autoresearch reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+description: >
+  Use when user types /autoresearch, $autoresearch plan, $autoresearch debug,
+  $autoresearch fix, $autoresearch security, $autoresearch ship,
+  $autoresearch scenario, $autoresearch predict, $autoresearch learn, or
+  $autoresearch reason, or mentions "autoresearch" with a goal/metric.
+  Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles
+  to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via
+  Iterations: N inline config.
 metadata:
   source: claude-port
   version: 1.9.12

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: autoresearch
-description: Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+description: >
+  Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug,
+  /autoresearch:fix, /autoresearch:security, /autoresearch:ship,
+  /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or
+  /autoresearch:reason, or mentions "autoresearch" with a goal/metric.
+  Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles
+  to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via
+  Iterations: N inline config.
 version: 1.9.12
 ---
 

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: autoresearch
-description: Use when user types /autoresearch, /autoresearch_plan, /autoresearch_debug, /autoresearch_fix, /autoresearch_security, /autoresearch_ship, /autoresearch_scenario, /autoresearch_predict, /autoresearch_learn, or /autoresearch_reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+description: >
+  Use when user types /autoresearch, /autoresearch_plan, /autoresearch_debug,
+  /autoresearch_fix, /autoresearch_security, /autoresearch_ship,
+  /autoresearch_scenario, /autoresearch_predict, /autoresearch_learn, or
+  /autoresearch_reason, or mentions "autoresearch" with a goal/metric.
+  Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles
+  to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via
+  Iterations: N inline config.
 compatibility: opencode
 metadata:
   source: claude-port

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: autoresearch
-description: Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug, /autoresearch:fix, /autoresearch:security, /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or /autoresearch:reason, or mentions "autoresearch" with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline config.
+description: >
+  Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug,
+  /autoresearch:fix, /autoresearch:security, /autoresearch:ship,
+  /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn, or
+  /autoresearch:reason, or mentions "autoresearch" with a goal/metric.
+  Autonomous Goal-directed Iteration — apply Karpathy's autoresearch principles
+  to ANY task: modify, verify, keep/discard, repeat. Supports bounded mode via
+  Iterations: N inline config.
 version: 1.9.12
 ---
 

--- a/scripts/sync-codex.sh
+++ b/scripts/sync-codex.sh
@@ -67,7 +67,7 @@ content = content.replace('# Claude Autoresearch', '# Codex Autoresearch', 1)
 
 # Replace version frontmatter with Codex-compatible metadata
 content = re.sub(
-    r'^(---\nname: autoresearch\ndescription: .*?\n)version: ([\d.]+)\n(---)',
+    r'^(---\nname: autoresearch\ndescription: (?:.*?\n|>\n(?:  .*\n)+))version: ([\d.]+)\n(---)',
     r'\1metadata:\n  source: claude-port\n  version: \2\n  short-description: Autonomous goal-directed iteration engine\n\3',
     content,
     count=1,

--- a/scripts/sync-opencode.sh
+++ b/scripts/sync-opencode.sh
@@ -62,7 +62,7 @@ content = content.replace('# Claude Autoresearch', '# OpenCode Autoresearch', 1)
 # Replace version frontmatter with OpenCode-compatible metadata
 import re
 content = re.sub(
-    r'^(---\nname: autoresearch\ndescription: .*?\n)version: ([\d.]+)\n(---)',
+    r'^(---\nname: autoresearch\ndescription: (?:.*?\n|>\n(?:  .*\n)+))version: ([\d.]+)\n(---)',
     r'\1compatibility: opencode\nmetadata:\n  source: claude-port\n  version: \2\n\3',
     content,
     count=1,


### PR DESCRIPTION
## Summary

- Use folded block scalars for the autoresearch skill descriptions so colon-containing text stays valid YAML.
- Update the Codex and OpenCode sync scripts so regenerated skill frontmatter preserves the fix.

## Context

Closes #69.
Related to #71.

The current one-line `description:` values include colon-delimited phrases like `ANY task: ...` and `Iterations: N`, which can make YAML parsers reject the skill frontmatter.

## Validation

- [x] `bash scripts/sync-codex.sh`
- [x] `bash scripts/sync-opencode.sh`
- [x] Parsed all `**/SKILL.md` frontmatter with PyYAML successfully.

## Notes

This keeps the description text semantically the same and only changes YAML formatting plus sync-script compatibility.
