### PR TITLE
fix: imperative skill descriptions for reliable triggering

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: autoresearch
 description: >-
-  Use when user types /autoresearch, $autoresearch plan, $autoresearch debug,
-  $autoresearch fix, $autoresearch security, $autoresearch ship,
-  $autoresearch scenario, $autoresearch predict, $autoresearch learn,
-  $autoresearch reason, $autoresearch reason --iterations N, or
-  $autoresearch probe, or mentions "autoresearch" with a goal/metric. Trigger
-  even when the invocation is embedded in prose. Autonomous Goal-directed
-  Iteration — apply Karpathy's autoresearch principles to ANY task: modify,
-  verify, keep/discard, repeat. Supports bounded mode via Iterations: N inline
-  config or --iterations N flags.
+  ALWAYS activate when user types /autoresearch, $autoresearch plan,
+  $autoresearch debug, $autoresearch fix, $autoresearch security,
+  $autoresearch ship, $autoresearch scenario, $autoresearch predict,
+  $autoresearch learn, $autoresearch reason, or $autoresearch probe.
+  MUST also activate when user mentions "autoresearch" with ANY goal,
+  metric, or task, even when the invocation is embedded in prose.
+  This is a BLOCKING skill invocation — invoke BEFORE generating any
+  other response.
 metadata:
   source: claude-port
   version: 2.0.03

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: autoresearch
 description: >-
-  Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug,
-  /autoresearch:fix, /autoresearch:security, /autoresearch:ship,
-  /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn,
-  /autoresearch:reason, or /autoresearch:probe, or mentions "autoresearch"
-  with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's
-  autoresearch principles to ANY task: modify, verify, keep/discard, repeat.
-  Supports bounded mode via Iterations: N inline config.
+  ALWAYS activate when user types /autoresearch, /autoresearch:plan,
+  /autoresearch:debug, /autoresearch:fix, /autoresearch:security,
+  /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict,
+  /autoresearch:learn, /autoresearch:reason, or /autoresearch:probe.
+  MUST also activate when user mentions "autoresearch" with ANY goal,
+  metric, or task. This is a BLOCKING skill invocation — invoke BEFORE
+  generating any other response.
 version: 2.0.03
 ---
 

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: autoresearch
 description: >-
-  Use when user types /autoresearch, /autoresearch_plan, /autoresearch_debug,
-  /autoresearch_fix, /autoresearch_security, /autoresearch_ship,
-  /autoresearch_scenario, /autoresearch_predict, /autoresearch_learn,
-  /autoresearch_reason, or /autoresearch_probe, or mentions "autoresearch"
-  with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's
-  autoresearch principles to ANY task: modify, verify, keep/discard, repeat.
-  Supports bounded mode via Iterations: N inline config.
+  ALWAYS activate when user types /autoresearch, /autoresearch_plan,
+  /autoresearch_debug, /autoresearch_fix, /autoresearch_security,
+  /autoresearch_ship, /autoresearch_scenario, /autoresearch_predict,
+  /autoresearch_learn, /autoresearch_reason, or /autoresearch_probe.
+  MUST also activate when user mentions "autoresearch" with ANY goal,
+  metric, or task. This is a BLOCKING skill invocation — invoke BEFORE
+  generating any other response.
 compatibility: opencode
 metadata:
   source: claude-port

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: autoresearch
 description: >-
-  Use when user types /autoresearch, /autoresearch:plan, /autoresearch:debug,
-  /autoresearch:fix, /autoresearch:security, /autoresearch:ship,
-  /autoresearch:scenario, /autoresearch:predict, /autoresearch:learn,
-  /autoresearch:reason, or /autoresearch:probe, or mentions "autoresearch"
-  with a goal/metric. Autonomous Goal-directed Iteration — apply Karpathy's
-  autoresearch principles to ANY task: modify, verify, keep/discard, repeat.
-  Supports bounded mode via Iterations: N inline config.
+  ALWAYS activate when user types /autoresearch, /autoresearch:plan,
+  /autoresearch:debug, /autoresearch:fix, /autoresearch:security,
+  /autoresearch:ship, /autoresearch:scenario, /autoresearch:predict,
+  /autoresearch:learn, /autoresearch:reason, or /autoresearch:probe.
+  MUST also activate when user mentions "autoresearch" with ANY goal,
+  metric, or task. This is a BLOCKING skill invocation — invoke BEFORE
+  generating any other response.
 version: 2.0.03
 ---
 

--- a/plugins/autoresearch/skills/autoresearch/SKILL.md
+++ b/plugins/autoresearch/skills/autoresearch/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: autoresearch
-description: Use when the user wants autoresearch, mentions `autoresearch`, `autoresearch:plan`, `autoresearch:debug`, `autoresearch:fix`, `autoresearch:security`, `autoresearch:ship`, `autoresearch:scenario`, `autoresearch:predict`, `autoresearch:learn`, `autoresearch:reason`, `autoresearch:probe`, `$autoresearch`, `$autoresearch:<subcommand>`, `$autoresearch <subcommand>`, `$autoresearch reason --iterations N`, `/autoresearch`, or `/autoresearch:<subcommand>`, even when the invocation is embedded in prose, or asks for the same command surface in Codex with flags, inline config, chained workflows, or autonomous iteration.
+description: >-
+  ALWAYS activate when user mentions autoresearch, autoresearch:plan,
+  autoresearch:debug, autoresearch:fix, autoresearch:security,
+  autoresearch:ship, autoresearch:scenario, autoresearch:predict,
+  autoresearch:learn, autoresearch:reason, autoresearch:probe,
+  $autoresearch, $autoresearch:<subcommand>, or /autoresearch:<subcommand>,
+  even when embedded in prose. This is a BLOCKING skill invocation —
+  invoke BEFORE generating any other response.
 ---
 
 # Autoresearch For Codex


### PR DESCRIPTION
## Summary
- Change SKILL.md `description` from passive "Use when user types..." to imperative "ALWAYS activate...MUST...BLOCKING" across all 5 distributions (.claude, .agents, .opencode, claude-plugin, plugins/autoresearch)
- Matches pattern used by reliably-triggering skills (cook, fix) that never fail to activate
- Root cause: with 150+ skills competing, the passive description caused Claude to skip invocation unless user added emphatic override language

## Test plan
- [x] All 12 unit tests pass
- [x] Updated description visible in skills list (confirmed live in session)
- [ ] Verify `/autoresearch:probe` triggers without emphatic language in new session