### PR TITLE
chore: release v2.0.04

### DIFF
--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   MUST also activate when user mentions "autoresearch" with ANY goal,
   metric, or task. This is a BLOCKING skill invocation — invoke BEFORE
   generating any other response.
-version: 2.0.03
+version: 2.0.04
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   MUST also activate when user mentions "autoresearch" with ANY goal,
   metric, or task. This is a BLOCKING skill invocation — invoke BEFORE
   generating any other response.
-version: 2.0.03
+version: 2.0.04
 ---
 
 # Claude Autoresearch — Autonomous Goal-directed Iteration

--- a/plugins/autoresearch/.codex-plugin/plugin.json
+++ b/plugins/autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoresearch",
-  "version": "2.0.03-codex.0",
+  "version": "2.0.04-codex.0",
   "description": "Autonomous improvement engine for Codex. Preserves the autoresearch command surface with the Codex skill and wrapper CLI.",
   "author": {
     "name": "Udit Goenka",

--- a/plugins/autoresearch/resources/autoresearch-command-spec.json
+++ b/plugins/autoresearch/resources/autoresearch-command-spec.json
@@ -1,6 +1,6 @@
 {
   "name": "autoresearch",
-  "version": "2.0.03-codex.0",
+  "version": "2.0.04-codex.0",
   "runtime_translation": {
     "interactive_setup_tool": "request_user_input",
     "fallback_interactive_setup": "Ask concise direct questions when the structured tool is unavailable",

--- a/plugins/autoresearch/skills/autoresearch/resources/autoresearch-command-spec.json
+++ b/plugins/autoresearch/skills/autoresearch/resources/autoresearch-command-spec.json
@@ -1,6 +1,6 @@
 {
   "name": "autoresearch",
-  "version": "2.0.03-codex.0",
+  "version": "2.0.04-codex.0",
   "runtime_translation": {
     "interactive_setup_tool": "request_user_input",
     "fallback_interactive_setup": "Ask concise direct questions when the structured tool is unavailable",


### PR DESCRIPTION
## Summary
- Bump version to 2.0.04 across all distributions

## What's in v2.0.04
- **Reliable skill triggering** — SKILL.md descriptions changed from passive to imperative "ALWAYS activate...MUST...BLOCKING"
- **Probe subcommand recognition** — Restored command spec to Codex skill resources dir
- **Codex CLI hardening** — All invocation forms reliably parsed

## Test plan
- [x] All 12 unit tests pass
- [x] Command spec accessible from both Router paths