### PR TITLE
feat(learn): add wiki knowledge-base generation mode

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -24,7 +24,7 @@ version: 2.1.0
 | `$autoresearch ship` | Ship through 8 phases: checklist → dry-run → deploy → verify | N/A |
 | `$autoresearch scenario` | Generate edge cases across 12 dimensions | 20 |
 | `$autoresearch predict` | 5 expert personas debate before implementation | N/A |
-| `$autoresearch learn` | Scout codebase → generate docs → validate → fix loop | 10 |
+| `$autoresearch learn` | Scout codebase → generate docs or wiki → validate → fix loop | 10 |
 | `$autoresearch reason` | Adversarial debate with blind judges until convergence | 8 |
 | `$autoresearch probe` | 8 personas interrogate requirements until saturation | 15 |
 | `$autoresearch improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |

--- a/.agents/skills/autoresearch/learn.md
+++ b/.agents/skills/autoresearch/learn.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:learn
-description: "Scout codebase and auto-generate docs with validation-fix loop"
-argument-hint: "[Mode: <init|update|check|summarize>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--evals]"
+description: "Scout codebase and auto-generate docs — or a navigable wiki knowledge base — with validation-fix loop"
+argument-hint: "[Mode: <init|update|check|summarize|wiki>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--modules <list>] [--force] [--evals]"
 ---
 
 EXECUTE IMMEDIATELY.
@@ -9,12 +9,14 @@ EXECUTE IMMEDIATELY.
 ## Parse Arguments
 
 Extract from $ARGUMENTS:
-- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview)
+- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview), wiki (navigable knowledge base)
 - `Scope:` or `--scope` — file globs to document
 - `Depth:` or `--depth` — overview, standard, comprehensive
 - `--file <path>` — specific file to document
 - `--scan` — force fresh codebase scout
 - `--topics` — comma-separated focus topics
+- `--modules <list>` — wiki mode: comma-separated module names/paths overriding auto-detection
+- `--force` — wiki mode: regenerate all pages from scratch, ignore existing manifest
 - `--no-fix` — validate only, don't auto-fix issues
 - `--format` — markdown (default), json, rst
 - `Iterations:` or `--iterations` — default 10. "unlimited" for unbounded.
@@ -23,7 +25,7 @@ Extract from $ARGUMENTS:
 ## Setup (if Mode or Scope missing)
 
 request_user_input (single batch):
-  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview)
+  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview), wiki (knowledge base)
   Q2 (Scope): "Which files?" — suggested globs + entire codebase
   Q3 (Depth): "How detailed?" — overview only, standard, comprehensive
   Q4 (Topics): "Focus on?" — architecture, API, database, testing, all
@@ -43,6 +45,42 @@ If mode == summarize:
 - One-shot: scan codebase → produce structured summary
 - Write summary.md to output directory
 - Skip iteration loop entirely
+
+## Wiki Mode (no per-file loop)
+
+If mode == wiki: reuse Scout (Phase 1) + Analyze output, then generate a navigable `wiki/` knowledge base. Skip the init/update/check loop. Metric = `pages_generated / pages_planned × 100` (from manifest); size target 300 lines/page.
+
+### Module Discovery (priority order)
+1. `--modules` flag (explicit override, always wins; every path must resolve inside project root — reject escapes)
+2. Monorepo workspaces (`workspaces` in package.json, Cargo workspace members, `pnpm-workspace.yaml`)
+3. Per-directory project files (`pyproject.toml`, `Cargo.toml`, `go.mod`, `*.csproj`)
+4. Heuristic: dirs with 3+ source files (code extensions only — .ts/.py/.go/.rs/.java/.rb/.swift/.kt/.c/.cpp/.cs; tests count, config/markdown don't); nested dirs roll up to nearest module ancestor
+
+Cap 10 modules. If >10, group by top-level dir; if a group has >5 sub-modules, expand and take 10 largest by file count.
+
+### Plan (write-ahead)
+1. `mkdir -p wiki/modules/`; append `wiki-manifest.json` to `.gitignore` if absent
+2. Write `wiki-manifest.json` BEFORE generating — `{version:"1", generated_at, generation_status:"in_progress", modules_detected:[…], pages_planned:N, pages:{ "wiki/architecture.md":{status:"pending",type:"architecture"}, "wiki/modules/<name>.md":{…"module"}, "wiki/glossary.md":{…}, "wiki/onboarding.md":{…}, "wiki/index.md":{…} }}`
+3. Write stub `wiki/index.md` listing every planned page as `[pending]` (navigation survives interruption)
+4. Resume: if valid manifest exists → `--force` deletes it and regenerates all, else skip `"generated"` pages and only do `"pending"`. Corrupted manifest (invalid JSON, or missing `version`/`pages`) without `--force` → error directing user to `--force`.
+
+### Generate (priority-first, one agent call per page, bounded context)
+1. `architecture.md` — system overview from scout context. Up to 5 Mermaid diagrams, 3 types only (`graph TD`, `sequenceDiagram`, `classDiagram`); include one canonical example of each in the prompt; pick by signal.
+2. Module pages (alphabetical) — per-module agent gets: (a) file listing, (b) first 50 lines of ≤10 key files (entry points → largest → alphabetical), (c) Phase 2 overview. Required sections: Overview, Key Files; optional: Patterns/API/Dependencies/Getting Started.
+3. `glossary.md` — domain terms from class names, exports, types, comments; filter language keywords + stdlib; soft cap ~60-80, prioritize terms in 3+ files.
+4. `onboarding.md` — reading order, env setup, first-contribution workflow, gotchas. Sources: dir structure, README/docs, manifests, entry-point sampling, `git log --since='6 months ago'` directory frequency (skip with note if not a git repo or >10s).
+5. `index.md` — final pass: replace stub with real page descriptions + reading order.
+
+### Per-page contract
+- `generated_by: autoresearch` in YAML frontmatter
+- ~300 lines/page (soft); Mermaid ≤15 nodes/diagram; forward-only cross-links, ≤10 per page
+
+### Safety
+- **Secrets (2-layer):** (1) prompt instructs "summarize config, never include verbatim values from .env/credentials or strings matching key/secret/token/password; extract env var *names* not *values*"; (2) post-gen, `grep -rlE '(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|password\s*[:=]\s*\S+|mongodb(\+srv)?://\S+|postgres(ql)?://\S+)' wiki/` and warn (non-blocking) in the report.
+- **Name collision:** before overwriting a page, check for `generated_by: autoresearch` frontmatter; if absent (user-created) skip with warning. `--force` overrides.
+
+### Finish
+After each page is written, flip its manifest entry `pending`→`generated` (interrupt-safe). When all done, set `generation_status:"complete"`. Then run Phase 3 (Validate) with wiki path swap: replace `docs/` with `wiki/` (`ls wiki/*.md wiki/modules/*.md 2>/dev/null`), use maxLoc 300. Output: `✓ Wiki: [N] modules, [M] pages generated`.
 
 ## Iteration Loop (init/update/check modes)
 

--- a/.claude/commands/autoresearch/learn.md
+++ b/.claude/commands/autoresearch/learn.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:learn
-description: "Scout codebase and auto-generate docs with validation-fix loop"
-argument-hint: "[Mode: <init|update|check|summarize>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--evals]"
+description: "Scout codebase and auto-generate docs — or a navigable wiki knowledge base — with validation-fix loop"
+argument-hint: "[Mode: <init|update|check|summarize|wiki>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--modules <list>] [--force] [--evals]"
 ---
 
 EXECUTE IMMEDIATELY.
@@ -9,12 +9,14 @@ EXECUTE IMMEDIATELY.
 ## Parse Arguments
 
 Extract from $ARGUMENTS:
-- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview)
+- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview), wiki (navigable knowledge base)
 - `Scope:` or `--scope` — file globs to document
 - `Depth:` or `--depth` — overview, standard, comprehensive
 - `--file <path>` — specific file to document
 - `--scan` — force fresh codebase scout
 - `--topics` — comma-separated focus topics
+- `--modules <list>` — wiki mode: comma-separated module names/paths overriding auto-detection
+- `--force` — wiki mode: regenerate all pages from scratch, ignore existing manifest
 - `--no-fix` — validate only, don't auto-fix issues
 - `--format` — markdown (default), json, rst
 - `Iterations:` or `--iterations` — default 10. "unlimited" for unbounded.
@@ -23,7 +25,7 @@ Extract from $ARGUMENTS:
 ## Setup (if Mode or Scope missing)
 
 AskUserQuestion (single batch):
-  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview)
+  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview), wiki (knowledge base)
   Q2 (Scope): "Which files?" — suggested globs + entire codebase
   Q3 (Depth): "How detailed?" — overview only, standard, comprehensive
   Q4 (Topics): "Focus on?" — architecture, API, database, testing, all
@@ -43,6 +45,42 @@ If mode == summarize:
 - One-shot: scan codebase → produce structured summary
 - Write summary.md to output directory
 - Skip iteration loop entirely
+
+## Wiki Mode (no per-file loop)
+
+If mode == wiki: reuse Scout (Phase 1) + Analyze output, then generate a navigable `wiki/` knowledge base. Skip the init/update/check loop. Metric = `pages_generated / pages_planned × 100` (from manifest); size target 300 lines/page.
+
+### Module Discovery (priority order)
+1. `--modules` flag (explicit override, always wins; every path must resolve inside project root — reject escapes)
+2. Monorepo workspaces (`workspaces` in package.json, Cargo workspace members, `pnpm-workspace.yaml`)
+3. Per-directory project files (`pyproject.toml`, `Cargo.toml`, `go.mod`, `*.csproj`)
+4. Heuristic: dirs with 3+ source files (code extensions only — .ts/.py/.go/.rs/.java/.rb/.swift/.kt/.c/.cpp/.cs; tests count, config/markdown don't); nested dirs roll up to nearest module ancestor
+
+Cap 10 modules. If >10, group by top-level dir; if a group has >5 sub-modules, expand and take 10 largest by file count.
+
+### Plan (write-ahead)
+1. `mkdir -p wiki/modules/`; append `wiki-manifest.json` to `.gitignore` if absent
+2. Write `wiki-manifest.json` BEFORE generating — `{version:"1", generated_at, generation_status:"in_progress", modules_detected:[…], pages_planned:N, pages:{ "wiki/architecture.md":{status:"pending",type:"architecture"}, "wiki/modules/<name>.md":{…"module"}, "wiki/glossary.md":{…}, "wiki/onboarding.md":{…}, "wiki/index.md":{…} }}`
+3. Write stub `wiki/index.md` listing every planned page as `[pending]` (navigation survives interruption)
+4. Resume: if valid manifest exists → `--force` deletes it and regenerates all, else skip `"generated"` pages and only do `"pending"`. Corrupted manifest (invalid JSON, or missing `version`/`pages`) without `--force` → error directing user to `--force`.
+
+### Generate (priority-first, one agent call per page, bounded context)
+1. `architecture.md` — system overview from scout context. Up to 5 Mermaid diagrams, 3 types only (`graph TD`, `sequenceDiagram`, `classDiagram`); include one canonical example of each in the prompt; pick by signal.
+2. Module pages (alphabetical) — per-module agent gets: (a) file listing, (b) first 50 lines of ≤10 key files (entry points → largest → alphabetical), (c) Phase 2 overview. Required sections: Overview, Key Files; optional: Patterns/API/Dependencies/Getting Started.
+3. `glossary.md` — domain terms from class names, exports, types, comments; filter language keywords + stdlib; soft cap ~60-80, prioritize terms in 3+ files.
+4. `onboarding.md` — reading order, env setup, first-contribution workflow, gotchas. Sources: dir structure, README/docs, manifests, entry-point sampling, `git log --since='6 months ago'` directory frequency (skip with note if not a git repo or >10s).
+5. `index.md` — final pass: replace stub with real page descriptions + reading order.
+
+### Per-page contract
+- `generated_by: autoresearch` in YAML frontmatter
+- ~300 lines/page (soft); Mermaid ≤15 nodes/diagram; forward-only cross-links, ≤10 per page
+
+### Safety
+- **Secrets (2-layer):** (1) prompt instructs "summarize config, never include verbatim values from .env/credentials or strings matching key/secret/token/password; extract env var *names* not *values*"; (2) post-gen, `grep -rlE '(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|password\s*[:=]\s*\S+|mongodb(\+srv)?://\S+|postgres(ql)?://\S+)' wiki/` and warn (non-blocking) in the report.
+- **Name collision:** before overwriting a page, check for `generated_by: autoresearch` frontmatter; if absent (user-created) skip with warning. `--force` overrides.
+
+### Finish
+After each page is written, flip its manifest entry `pending`→`generated` (interrupt-safe). When all done, set `generation_status:"complete"`. Then run Phase 3 (Validate) with wiki path swap: replace `docs/` with `wiki/` (`ls wiki/*.md wiki/modules/*.md 2>/dev/null`), use maxLoc 300. Output: `✓ Wiki: [N] modules, [M] pages generated`.
 
 ## Iteration Loop (init/update/check modes)
 

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -24,7 +24,7 @@ version: 2.1.0
 | `/autoresearch:ship` | Ship through 8 phases: checklist → dry-run → deploy → verify | N/A |
 | `/autoresearch:scenario` | Generate edge cases across 12 dimensions | 20 |
 | `/autoresearch:predict` | 5 expert personas debate before implementation | N/A |
-| `/autoresearch:learn` | Scout codebase → generate docs → validate → fix loop | 10 |
+| `/autoresearch:learn` | Scout codebase → generate docs or wiki → validate → fix loop | 10 |
 | `/autoresearch:reason` | Adversarial debate with blind judges until convergence | 8 |
 | `/autoresearch:probe` | 8 personas interrogate requirements until saturation | 15 |
 | `/autoresearch:improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |

--- a/.opencode/commands/autoresearch_learn.md
+++ b/.opencode/commands/autoresearch_learn.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch_learn
-description: "Scout codebase and auto-generate docs with validation-fix loop"
-argument-hint: "[Mode: <init|update|check|summarize>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--evals]"
+description: "Scout codebase and auto-generate docs — or a navigable wiki knowledge base — with validation-fix loop"
+argument-hint: "[Mode: <init|update|check|summarize|wiki>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--modules <list>] [--force] [--evals]"
 ---
 
 EXECUTE IMMEDIATELY.
@@ -9,12 +9,14 @@ EXECUTE IMMEDIATELY.
 ## Parse Arguments
 
 Extract from $ARGUMENTS:
-- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview)
+- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview), wiki (navigable knowledge base)
 - `Scope:` or `--scope` — file globs to document
 - `Depth:` or `--depth` — overview, standard, comprehensive
 - `--file <path>` — specific file to document
 - `--scan` — force fresh codebase scout
 - `--topics` — comma-separated focus topics
+- `--modules <list>` — wiki mode: comma-separated module names/paths overriding auto-detection
+- `--force` — wiki mode: regenerate all pages from scratch, ignore existing manifest
 - `--no-fix` — validate only, don't auto-fix issues
 - `--format` — markdown (default), json, rst
 - `Iterations:` or `--iterations` — default 10. "unlimited" for unbounded.
@@ -23,7 +25,7 @@ Extract from $ARGUMENTS:
 ## Setup (if Mode or Scope missing)
 
 question (single batch):
-  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview)
+  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview), wiki (knowledge base)
   Q2 (Scope): "Which files?" — suggested globs + entire codebase
   Q3 (Depth): "How detailed?" — overview only, standard, comprehensive
   Q4 (Topics): "Focus on?" — architecture, API, database, testing, all
@@ -43,6 +45,42 @@ If mode == summarize:
 - One-shot: scan codebase → produce structured summary
 - Write summary.md to output directory
 - Skip iteration loop entirely
+
+## Wiki Mode (no per-file loop)
+
+If mode == wiki: reuse Scout (Phase 1) + Analyze output, then generate a navigable `wiki/` knowledge base. Skip the init/update/check loop. Metric = `pages_generated / pages_planned × 100` (from manifest); size target 300 lines/page.
+
+### Module Discovery (priority order)
+1. `--modules` flag (explicit override, always wins; every path must resolve inside project root — reject escapes)
+2. Monorepo workspaces (`workspaces` in package.json, Cargo workspace members, `pnpm-workspace.yaml`)
+3. Per-directory project files (`pyproject.toml`, `Cargo.toml`, `go.mod`, `*.csproj`)
+4. Heuristic: dirs with 3+ source files (code extensions only — .ts/.py/.go/.rs/.java/.rb/.swift/.kt/.c/.cpp/.cs; tests count, config/markdown don't); nested dirs roll up to nearest module ancestor
+
+Cap 10 modules. If >10, group by top-level dir; if a group has >5 sub-modules, expand and take 10 largest by file count.
+
+### Plan (write-ahead)
+1. `mkdir -p wiki/modules/`; append `wiki-manifest.json` to `.gitignore` if absent
+2. Write `wiki-manifest.json` BEFORE generating — `{version:"1", generated_at, generation_status:"in_progress", modules_detected:[…], pages_planned:N, pages:{ "wiki/architecture.md":{status:"pending",type:"architecture"}, "wiki/modules/<name>.md":{…"module"}, "wiki/glossary.md":{…}, "wiki/onboarding.md":{…}, "wiki/index.md":{…} }}`
+3. Write stub `wiki/index.md` listing every planned page as `[pending]` (navigation survives interruption)
+4. Resume: if valid manifest exists → `--force` deletes it and regenerates all, else skip `"generated"` pages and only do `"pending"`. Corrupted manifest (invalid JSON, or missing `version`/`pages`) without `--force` → error directing user to `--force`.
+
+### Generate (priority-first, one agent call per page, bounded context)
+1. `architecture.md` — system overview from scout context. Up to 5 Mermaid diagrams, 3 types only (`graph TD`, `sequenceDiagram`, `classDiagram`); include one canonical example of each in the prompt; pick by signal.
+2. Module pages (alphabetical) — per-module agent gets: (a) file listing, (b) first 50 lines of ≤10 key files (entry points → largest → alphabetical), (c) Phase 2 overview. Required sections: Overview, Key Files; optional: Patterns/API/Dependencies/Getting Started.
+3. `glossary.md` — domain terms from class names, exports, types, comments; filter language keywords + stdlib; soft cap ~60-80, prioritize terms in 3+ files.
+4. `onboarding.md` — reading order, env setup, first-contribution workflow, gotchas. Sources: dir structure, README/docs, manifests, entry-point sampling, `git log --since='6 months ago'` directory frequency (skip with note if not a git repo or >10s).
+5. `index.md` — final pass: replace stub with real page descriptions + reading order.
+
+### Per-page contract
+- `generated_by: autoresearch` in YAML frontmatter
+- ~300 lines/page (soft); Mermaid ≤15 nodes/diagram; forward-only cross-links, ≤10 per page
+
+### Safety
+- **Secrets (2-layer):** (1) prompt instructs "summarize config, never include verbatim values from .env/credentials or strings matching key/secret/token/password; extract env var *names* not *values*"; (2) post-gen, `grep -rlE '(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|password\s*[:=]\s*\S+|mongodb(\+srv)?://\S+|postgres(ql)?://\S+)' wiki/` and warn (non-blocking) in the report.
+- **Name collision:** before overwriting a page, check for `generated_by: autoresearch` frontmatter; if absent (user-created) skip with warning. `--force` overrides.
+
+### Finish
+After each page is written, flip its manifest entry `pending`→`generated` (interrupt-safe). When all done, set `generation_status:"complete"`. Then run Phase 3 (Validate) with wiki path swap: replace `docs/` with `wiki/` (`ls wiki/*.md wiki/modules/*.md 2>/dev/null`), use maxLoc 300. Output: `✓ Wiki: [N] modules, [M] pages generated`.
 
 ## Iteration Loop (init/update/check modes)
 

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -24,7 +24,7 @@ version: 2.1.0
 | `/autoresearch_ship` | Ship through 8 phases: checklist → dry-run → deploy → verify | N/A |
 | `/autoresearch_scenario` | Generate edge cases across 12 dimensions | 20 |
 | `/autoresearch_predict` | 5 expert personas debate before implementation | N/A |
-| `/autoresearch_learn` | Scout codebase → generate docs → validate → fix loop | 10 |
+| `/autoresearch_learn` | Scout codebase → generate docs or wiki → validate → fix loop | 10 |
 | `/autoresearch_reason` | Adversarial debate with blind judges until convergence | 8 |
 | `/autoresearch_probe` | 8 personas interrogate requirements until saturation | 15 |
 | `/autoresearch_improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |

--- a/claude-plugin/commands/autoresearch/learn.md
+++ b/claude-plugin/commands/autoresearch/learn.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:learn
-description: "Scout codebase and auto-generate docs with validation-fix loop"
-argument-hint: "[Mode: <init|update|check|summarize>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--evals]"
+description: "Scout codebase and auto-generate docs — or a navigable wiki knowledge base — with validation-fix loop"
+argument-hint: "[Mode: <init|update|check|summarize|wiki>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--modules <list>] [--force] [--evals]"
 ---
 
 EXECUTE IMMEDIATELY.
@@ -9,12 +9,14 @@ EXECUTE IMMEDIATELY.
 ## Parse Arguments
 
 Extract from $ARGUMENTS:
-- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview)
+- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview), wiki (navigable knowledge base)
 - `Scope:` or `--scope` — file globs to document
 - `Depth:` or `--depth` — overview, standard, comprehensive
 - `--file <path>` — specific file to document
 - `--scan` — force fresh codebase scout
 - `--topics` — comma-separated focus topics
+- `--modules <list>` — wiki mode: comma-separated module names/paths overriding auto-detection
+- `--force` — wiki mode: regenerate all pages from scratch, ignore existing manifest
 - `--no-fix` — validate only, don't auto-fix issues
 - `--format` — markdown (default), json, rst
 - `Iterations:` or `--iterations` — default 10. "unlimited" for unbounded.
@@ -23,7 +25,7 @@ Extract from $ARGUMENTS:
 ## Setup (if Mode or Scope missing)
 
 AskUserQuestion (single batch):
-  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview)
+  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview), wiki (knowledge base)
   Q2 (Scope): "Which files?" — suggested globs + entire codebase
   Q3 (Depth): "How detailed?" — overview only, standard, comprehensive
   Q4 (Topics): "Focus on?" — architecture, API, database, testing, all
@@ -43,6 +45,42 @@ If mode == summarize:
 - One-shot: scan codebase → produce structured summary
 - Write summary.md to output directory
 - Skip iteration loop entirely
+
+## Wiki Mode (no per-file loop)
+
+If mode == wiki: reuse Scout (Phase 1) + Analyze output, then generate a navigable `wiki/` knowledge base. Skip the init/update/check loop. Metric = `pages_generated / pages_planned × 100` (from manifest); size target 300 lines/page.
+
+### Module Discovery (priority order)
+1. `--modules` flag (explicit override, always wins; every path must resolve inside project root — reject escapes)
+2. Monorepo workspaces (`workspaces` in package.json, Cargo workspace members, `pnpm-workspace.yaml`)
+3. Per-directory project files (`pyproject.toml`, `Cargo.toml`, `go.mod`, `*.csproj`)
+4. Heuristic: dirs with 3+ source files (code extensions only — .ts/.py/.go/.rs/.java/.rb/.swift/.kt/.c/.cpp/.cs; tests count, config/markdown don't); nested dirs roll up to nearest module ancestor
+
+Cap 10 modules. If >10, group by top-level dir; if a group has >5 sub-modules, expand and take 10 largest by file count.
+
+### Plan (write-ahead)
+1. `mkdir -p wiki/modules/`; append `wiki-manifest.json` to `.gitignore` if absent
+2. Write `wiki-manifest.json` BEFORE generating — `{version:"1", generated_at, generation_status:"in_progress", modules_detected:[…], pages_planned:N, pages:{ "wiki/architecture.md":{status:"pending",type:"architecture"}, "wiki/modules/<name>.md":{…"module"}, "wiki/glossary.md":{…}, "wiki/onboarding.md":{…}, "wiki/index.md":{…} }}`
+3. Write stub `wiki/index.md` listing every planned page as `[pending]` (navigation survives interruption)
+4. Resume: if valid manifest exists → `--force` deletes it and regenerates all, else skip `"generated"` pages and only do `"pending"`. Corrupted manifest (invalid JSON, or missing `version`/`pages`) without `--force` → error directing user to `--force`.
+
+### Generate (priority-first, one agent call per page, bounded context)
+1. `architecture.md` — system overview from scout context. Up to 5 Mermaid diagrams, 3 types only (`graph TD`, `sequenceDiagram`, `classDiagram`); include one canonical example of each in the prompt; pick by signal.
+2. Module pages (alphabetical) — per-module agent gets: (a) file listing, (b) first 50 lines of ≤10 key files (entry points → largest → alphabetical), (c) Phase 2 overview. Required sections: Overview, Key Files; optional: Patterns/API/Dependencies/Getting Started.
+3. `glossary.md` — domain terms from class names, exports, types, comments; filter language keywords + stdlib; soft cap ~60-80, prioritize terms in 3+ files.
+4. `onboarding.md` — reading order, env setup, first-contribution workflow, gotchas. Sources: dir structure, README/docs, manifests, entry-point sampling, `git log --since='6 months ago'` directory frequency (skip with note if not a git repo or >10s).
+5. `index.md` — final pass: replace stub with real page descriptions + reading order.
+
+### Per-page contract
+- `generated_by: autoresearch` in YAML frontmatter
+- ~300 lines/page (soft); Mermaid ≤15 nodes/diagram; forward-only cross-links, ≤10 per page
+
+### Safety
+- **Secrets (2-layer):** (1) prompt instructs "summarize config, never include verbatim values from .env/credentials or strings matching key/secret/token/password; extract env var *names* not *values*"; (2) post-gen, `grep -rlE '(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|password\s*[:=]\s*\S+|mongodb(\+srv)?://\S+|postgres(ql)?://\S+)' wiki/` and warn (non-blocking) in the report.
+- **Name collision:** before overwriting a page, check for `generated_by: autoresearch` frontmatter; if absent (user-created) skip with warning. `--force` overrides.
+
+### Finish
+After each page is written, flip its manifest entry `pending`→`generated` (interrupt-safe). When all done, set `generation_status:"complete"`. Then run Phase 3 (Validate) with wiki path swap: replace `docs/` with `wiki/` (`ls wiki/*.md wiki/modules/*.md 2>/dev/null`), use maxLoc 300. Output: `✓ Wiki: [N] modules, [M] pages generated`.
 
 ## Iteration Loop (init/update/check modes)
 

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -24,9 +24,10 @@ version: 2.1.0
 | `/autoresearch:ship` | Ship through 8 phases: checklist → dry-run → deploy → verify | N/A |
 | `/autoresearch:scenario` | Generate edge cases across 12 dimensions | 20 |
 | `/autoresearch:predict` | 5 expert personas debate before implementation | N/A |
-| `/autoresearch:learn` | Scout codebase → generate docs → validate → fix loop | 10 |
+| `/autoresearch:learn` | Scout codebase → generate docs or wiki → validate → fix loop | 10 |
 | `/autoresearch:reason` | Adversarial debate with blind judges until convergence | 8 |
 | `/autoresearch:probe` | 8 personas interrogate requirements until saturation | 15 |
+| `/autoresearch:improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |
 | `/autoresearch:evals` | Analyze iteration results: trends, plateaus, regressions | N/A |
 
 ## Universal Flags

--- a/guide/autoresearch-learn.md
+++ b/guide/autoresearch-learn.md
@@ -23,7 +23,7 @@ Generated docs land in `docs/` directly. The `learn/` directory is the audit tra
 
 ---
 
-## 4 Modes
+## 5 Modes
 
 | Mode | What It Does | When to Use |
 |------|-------------|-------------|
@@ -31,6 +31,7 @@ Generated docs land in `docs/` directly. The `learn/` directory is the audit tra
 | `update` | Reads existing docs, refreshes stale content | Docs exist but may be stale |
 | `check` | Read-only health audit — no file writes | Before a release, quick pulse |
 | `summarize` | Creates/updates `codebase-summary.md` only | Onboarding, quick orientation |
+| `wiki` | Generates a navigable `wiki/` knowledge base with architecture diagrams, per-module deep dives, glossary, and onboarding guide | Developer KT sessions, onboarding, a "second brain" for the codebase |
 
 **Auto-detection:** if `docs/` has 0 files → defaults to `init`. If docs exist → defaults to `update`.
 
@@ -41,12 +42,14 @@ Generated docs land in `docs/` directly. The `learn/` directory is the audit tra
 | Flag | Purpose | Default |
 |------|---------|---------|
 | `Iterations: N` | Override default of 10 (validation-fix loop) | 10 |
-| `--mode <mode>` | `init`, `update`, `check`, `summarize` | Auto-detected |
+| `--mode <mode>` | `init`, `update`, `check`, `summarize`, `wiki` | Auto-detected |
 | `--scope <glob>` | Limit codebase learning to specific dirs | Everything |
 | `--depth <level>` | `quick`, `standard`, `deep` | `standard` |
 | `--file <name>` | Selective update — target one doc file | All docs |
 | `--scan` | Force fresh scout in summarize mode | false |
 | `--topics <list>` | Focus summarize on specific topics | All |
+| `--modules <list>` | Wiki mode: override module auto-detection with a comma-separated list | Auto-detect |
+| `--force` | Wiki mode: regenerate all pages from scratch, ignore manifest | false |
 | `--no-fix` | Skip validation-fix loop | false |
 | `--format <type>` | `markdown`, `html`, `json`, `rst` | markdown |
 | `--chain <targets>` | Chain to next command(s) after completion | none |
@@ -116,6 +119,61 @@ Generates all core docs plus `deployment-guide.md`, `design-guidelines.md`, and 
 ```
 /autoresearch:learn --mode update --no-fix
 ```
+
+### Generate a wiki knowledge base
+
+```
+/autoresearch:learn --mode wiki
+```
+
+Scouts the codebase, detects up to 10 modules, then generates a `wiki/` directory with: `index.md` (table of contents), `architecture.md` (system overview with Mermaid diagrams), per-module deep dives in `modules/`, `glossary.md` (domain terms from code), and `onboarding.md` (reading order, setup, gotchas). Pages are cross-linked and kept under ~300 lines. A manifest tracks progress for resume on interruption.
+
+### Wiki for specific modules
+
+```
+/autoresearch:learn --mode wiki --modules auth,api,payments
+```
+
+Overrides automatic module detection — only generates pages for the named modules. Useful when heuristics miss a module or you want a focused wiki.
+
+### Force-regenerate the wiki
+
+```
+/autoresearch:learn --mode wiki --force
+```
+
+Ignores the existing manifest and regenerates every page from scratch. Use after significant codebase changes or if the manifest is corrupted.
+
+### Wiki scoped to one subsystem
+
+```
+/autoresearch:learn --mode wiki --scope src/api/**
+```
+
+Generates pages only for modules within the scope — combines with auto-detection; modules outside the scope are dropped with a warning.
+
+---
+
+## Wiki Output Structure
+
+```
+wiki/
+├── index.md                    # TOC, numbered reading order
+├── architecture.md             # System overview with Mermaid diagrams
+├── modules/
+│   ├── auth.md                 # Per-module: purpose, key files, patterns
+│   ├── api.md
+│   └── ...                     # One page per detected module (cap: 10)
+├── glossary.md                 # Domain terms extracted from code
+├── onboarding.md               # Start here: reading order, setup, gotchas
+└── wiki-manifest.json          # Completion tracking (in .gitignore)
+```
+
+The wiki is **descriptive** (explains what the code does) — separate from `docs/`, which is **prescriptive** (tells developers what to do). Both coexist without conflict.
+
+**Resume:** if interrupted, re-running `wiki` mode picks up where it left off (pending pages only); `--force` regenerates everything.
+
+**Won't overwrite your content:** a custom page (one lacking `generated_by: autoresearch` frontmatter) is skipped with a warning. `--force` overrides.
 
 ---
 

--- a/plugins/autoresearch/skills/autoresearch/SKILL.md
+++ b/plugins/autoresearch/skills/autoresearch/SKILL.md
@@ -24,7 +24,7 @@ version: 2.1.0
 | `$autoresearch ship` | Ship through 8 phases: checklist → dry-run → deploy → verify | N/A |
 | `$autoresearch scenario` | Generate edge cases across 12 dimensions | 20 |
 | `$autoresearch predict` | 5 expert personas debate before implementation | N/A |
-| `$autoresearch learn` | Scout codebase → generate docs → validate → fix loop | 10 |
+| `$autoresearch learn` | Scout codebase → generate docs or wiki → validate → fix loop | 10 |
 | `$autoresearch reason` | Adversarial debate with blind judges until convergence | 8 |
 | `$autoresearch probe` | 8 personas interrogate requirements until saturation | 15 |
 | `$autoresearch improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |

--- a/plugins/autoresearch/skills/autoresearch/learn.md
+++ b/plugins/autoresearch/skills/autoresearch/learn.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch:learn
-description: "Scout codebase and auto-generate docs with validation-fix loop"
-argument-hint: "[Mode: <init|update|check|summarize>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--evals]"
+description: "Scout codebase and auto-generate docs — or a navigable wiki knowledge base — with validation-fix loop"
+argument-hint: "[Mode: <init|update|check|summarize|wiki>] [Scope: <glob>] [Iterations: N] [--depth <level>] [--modules <list>] [--force] [--evals]"
 ---
 
 EXECUTE IMMEDIATELY.
@@ -9,12 +9,14 @@ EXECUTE IMMEDIATELY.
 ## Parse Arguments
 
 Extract from $ARGUMENTS:
-- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview)
+- `Mode:` or `--mode` — init (create from scratch), update (refresh existing), check (validate), summarize (brief overview), wiki (navigable knowledge base)
 - `Scope:` or `--scope` — file globs to document
 - `Depth:` or `--depth` — overview, standard, comprehensive
 - `--file <path>` — specific file to document
 - `--scan` — force fresh codebase scout
 - `--topics` — comma-separated focus topics
+- `--modules <list>` — wiki mode: comma-separated module names/paths overriding auto-detection
+- `--force` — wiki mode: regenerate all pages from scratch, ignore existing manifest
 - `--no-fix` — validate only, don't auto-fix issues
 - `--format` — markdown (default), json, rst
 - `Iterations:` or `--iterations` — default 10. "unlimited" for unbounded.
@@ -23,7 +25,7 @@ Extract from $ARGUMENTS:
 ## Setup (if Mode or Scope missing)
 
 request_user_input (single batch):
-  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview)
+  Q1 (Mode): "What to do?" — init (generate docs), update (refresh), check (validate), summarize (overview), wiki (knowledge base)
   Q2 (Scope): "Which files?" — suggested globs + entire codebase
   Q3 (Depth): "How detailed?" — overview only, standard, comprehensive
   Q4 (Topics): "Focus on?" — architecture, API, database, testing, all
@@ -43,6 +45,42 @@ If mode == summarize:
 - One-shot: scan codebase → produce structured summary
 - Write summary.md to output directory
 - Skip iteration loop entirely
+
+## Wiki Mode (no per-file loop)
+
+If mode == wiki: reuse Scout (Phase 1) + Analyze output, then generate a navigable `wiki/` knowledge base. Skip the init/update/check loop. Metric = `pages_generated / pages_planned × 100` (from manifest); size target 300 lines/page.
+
+### Module Discovery (priority order)
+1. `--modules` flag (explicit override, always wins; every path must resolve inside project root — reject escapes)
+2. Monorepo workspaces (`workspaces` in package.json, Cargo workspace members, `pnpm-workspace.yaml`)
+3. Per-directory project files (`pyproject.toml`, `Cargo.toml`, `go.mod`, `*.csproj`)
+4. Heuristic: dirs with 3+ source files (code extensions only — .ts/.py/.go/.rs/.java/.rb/.swift/.kt/.c/.cpp/.cs; tests count, config/markdown don't); nested dirs roll up to nearest module ancestor
+
+Cap 10 modules. If >10, group by top-level dir; if a group has >5 sub-modules, expand and take 10 largest by file count.
+
+### Plan (write-ahead)
+1. `mkdir -p wiki/modules/`; append `wiki-manifest.json` to `.gitignore` if absent
+2. Write `wiki-manifest.json` BEFORE generating — `{version:"1", generated_at, generation_status:"in_progress", modules_detected:[…], pages_planned:N, pages:{ "wiki/architecture.md":{status:"pending",type:"architecture"}, "wiki/modules/<name>.md":{…"module"}, "wiki/glossary.md":{…}, "wiki/onboarding.md":{…}, "wiki/index.md":{…} }}`
+3. Write stub `wiki/index.md` listing every planned page as `[pending]` (navigation survives interruption)
+4. Resume: if valid manifest exists → `--force` deletes it and regenerates all, else skip `"generated"` pages and only do `"pending"`. Corrupted manifest (invalid JSON, or missing `version`/`pages`) without `--force` → error directing user to `--force`.
+
+### Generate (priority-first, one agent call per page, bounded context)
+1. `architecture.md` — system overview from scout context. Up to 5 Mermaid diagrams, 3 types only (`graph TD`, `sequenceDiagram`, `classDiagram`); include one canonical example of each in the prompt; pick by signal.
+2. Module pages (alphabetical) — per-module agent gets: (a) file listing, (b) first 50 lines of ≤10 key files (entry points → largest → alphabetical), (c) Phase 2 overview. Required sections: Overview, Key Files; optional: Patterns/API/Dependencies/Getting Started.
+3. `glossary.md` — domain terms from class names, exports, types, comments; filter language keywords + stdlib; soft cap ~60-80, prioritize terms in 3+ files.
+4. `onboarding.md` — reading order, env setup, first-contribution workflow, gotchas. Sources: dir structure, README/docs, manifests, entry-point sampling, `git log --since='6 months ago'` directory frequency (skip with note if not a git repo or >10s).
+5. `index.md` — final pass: replace stub with real page descriptions + reading order.
+
+### Per-page contract
+- `generated_by: autoresearch` in YAML frontmatter
+- ~300 lines/page (soft); Mermaid ≤15 nodes/diagram; forward-only cross-links, ≤10 per page
+
+### Safety
+- **Secrets (2-layer):** (1) prompt instructs "summarize config, never include verbatim values from .env/credentials or strings matching key/secret/token/password; extract env var *names* not *values*"; (2) post-gen, `grep -rlE '(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|password\s*[:=]\s*\S+|mongodb(\+srv)?://\S+|postgres(ql)?://\S+)' wiki/` and warn (non-blocking) in the report.
+- **Name collision:** before overwriting a page, check for `generated_by: autoresearch` frontmatter; if absent (user-created) skip with warning. `--force` overrides.
+
+### Finish
+After each page is written, flip its manifest entry `pending`→`generated` (interrupt-safe). When all done, set `generation_status:"complete"`. Then run Phase 3 (Validate) with wiki path swap: replace `docs/` with `wiki/` (`ls wiki/*.md wiki/modules/*.md 2>/dev/null`), use maxLoc 300. Output: `✓ Wiki: [N] modules, [M] pages generated`.
 
 ## Iteration Loop (init/update/check modes)
 


### PR DESCRIPTION
## Summary

Reworks the `--mode wiki` feature (originally proposed in #97, which was based on a stale pre-modular branch) onto the current modular `.claude/` structure. Adds a fifth `learn` mode that generates a navigable `wiki/` knowledge base instead of prescriptive `docs/`.

## What it does

`/autoresearch:learn --mode wiki` scouts the codebase, detects up to 10 modules, and generates:

- `index.md` — table of contents + reading order
- `architecture.md` — system overview with Mermaid diagrams (3 types, ≤15 nodes each)
- `modules/<name>.md` — per-module deep dives (purpose, key files, patterns)
- `glossary.md` — domain terms extracted from code
- `onboarding.md` — reading order, setup, gotchas

## Design

- **Write-ahead manifest** (`wiki-manifest.json`, gitignored) tracks per-page status → resume after interruption; `--force` regenerates everything.
- **`--modules <list>`** overrides automatic module detection.
- **Two-layer secrets filter:** prompt instruction to extract env var *names* not *values*, plus a post-generation regex scan (AWS keys, `sk-`/`ghp_` tokens, DB URIs, password assignments) that warns (non-blocking).
- **Won't clobber user content:** a page lacking `generated_by: autoresearch` frontmatter is skipped with a warning; `--force` overrides.

Wiki is **descriptive** (what the code does); `docs/` stays **prescriptive** (what developers should do). They coexist.

## Distribution parity

- Canonical edits in `.claude/` (command + thin SKILL.md router + guide).
- `.opencode/`, Codex (`plugins/`, `.agents/`) regenerated via `scripts/transform.sh`.
- `claude-plugin/` (the plugin install source) synced from `.claude/`. This sync also restores the `improve` command row that had drifted out of the distribution `SKILL.md`.

## Verification

- `bash tests/test-hooks.sh` → 105/105 passing.
- Confirmed wiki content present in all four distribution variants and platform invocation transforms applied.