### PR TITLE
Release v2.1.3 — Wiki Knowledge Base + Distribution Parity

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.0
+version: 2.1.3
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "2.1.0",
+  "version": "2.1.3",
   "description": "Claude Autoresearch \u2014 autonomous goal-directed iteration for Claude Code. 13 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve.",
   "owner": {
     "name": "Udit Goenka",
@@ -11,7 +11,7 @@
     {
       "name": "autoresearch",
       "description": "Autonomous improvement engine. 13 commands with bounded defaults, chain handoff, and adaptive evals checkpoints. 95% token reduction via modular architecture.",
-      "version": "2.1.0",
+      "version": "2.1.3",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.0
+version: 2.1.3
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.0
+version: 2.1.3
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) —
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
 [![OpenCode](https://img.shields.io/badge/OpenCode-Skill-purple)](https://opencode.ai)
 [![Codex](https://img.shields.io/badge/Codex-Skill-green?logo=openai&logoColor=white)](https://developers.openai.com/codex)
-[![Version](https://img.shields.io/badge/version-2.1.2-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-2.1.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
   "description": "Autonomous improvement engine. 13 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, improve, evals.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.0
+version: 2.1.3
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -2,6 +2,28 @@
 
 All notable changes to the autoresearch project are documented here.
 
+## v2.1.3 — Wiki Knowledge Base + Distribution Parity (2026-06-16)
+
+**Theme:** A navigable knowledge base from `learn`, plus a clean, fully-synced distribution across all platforms.
+
+### Added
+- `/autoresearch:learn --mode wiki` — generates a navigable `wiki/` knowledge base instead of prescriptive `docs/`
+  - `index.md`, `architecture.md` (Mermaid diagrams), per-module deep dives (`modules/`, cap 10), `glossary.md`, `onboarding.md`
+  - Write-ahead `wiki-manifest.json` (gitignored) for resume-after-interruption; `--force` regenerates from scratch
+  - `--modules <list>` overrides automatic module detection
+  - Two-layer secrets filter — prompt instruction (extract env var names, not values) + post-generation regex scan (AWS keys, `sk-`/`ghp_` tokens, DB URIs, password assignments), non-blocking warning
+  - Won't overwrite user-authored pages (skipped when `generated_by: autoresearch` frontmatter is absent)
+
+### Changed
+- Wiki examples and output-structure reference added to `guide/autoresearch-learn.md` (now 5 modes)
+- All distributions regenerated from `.claude/` source via `scripts/transform.sh` (OpenCode, Codex) and synced to `claude-plugin/` (install source)
+
+### Fixed
+- Distribution parity — `claude-plugin/` install source now carries the `improve` command row (had drifted out of the distribution `SKILL.md`)
+- Removed v2.1.0 wrapper-CLI leftovers that broke a fresh-clone test run (dead `bin/autoresearch` entrypoint and orphaned Python test modules)
+- Aligned command count to 13 across `AGENTS.md`, `marketplace.json`, and the Codex plugin manifest
+- Synced version fields across `marketplace.json` (was 2.1.0), the Codex plugin (was 2.1.0-codex.0), and both `SKILL.md` files
+
 ## v2.1.2 — Product Improvement Engine (2026-05-23)
 
 **Theme:** Outward-looking product strategy — "what should we build next?"

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Autoresearch v2.1.2 is a modular, markdown-driven autonomous iteration framework. The core architectural shift from v2.0.x is the **thin SKILL.md + self-contained command files** pattern: the skill file is a routing table; all protocol is embedded in 13 self-contained command files. Only the invoked command file loads per invocation, reducing token cost by ~95%.
+Autoresearch v2.1.3 is a modular, markdown-driven autonomous iteration framework. The core architectural shift from v2.0.x is the **thin SKILL.md + self-contained command files** pattern: the skill file is a routing table; all protocol is embedded in 13 self-contained command files. Only the invoked command file loads per invocation, reducing token cost by ~95%.
 
 Multi-platform: Claude Code, OpenCode, and Codex are all supported via a single `scripts/transform.sh` that produces platform-specific distributions from the canonical `.claude/` source.
 

--- a/guide/README.md
+++ b/guide/README.md
@@ -4,7 +4,7 @@
 
 **By [Udit Goenka](https://udit.co)**
 
-[![Version](https://img.shields.io/badge/version-2.1.2-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-2.1.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>

--- a/plugins/autoresearch/.codex-plugin/plugin.json
+++ b/plugins/autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoresearch",
-  "version": "2.1.0-codex.0",
+  "version": "2.1.3-codex.0",
   "description": "Autonomous improvement engine for Codex. 13 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve.",
   "author": {
     "name": "Udit Goenka",

--- a/plugins/autoresearch/skills/autoresearch/SKILL.md
+++ b/plugins/autoresearch/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.0
+version: 2.1.3
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration


### PR DESCRIPTION
## Release v2.1.3

Version bump only — all feature/cleanup work already landed on master via #98, #99, #100. This PR syncs version fields and the changelog.

**Version:** `2.1.2` → `2.1.3` (Codex: `2.1.0-codex.0` → `2.1.3-codex.0`)

### Headline
- `/autoresearch:learn --mode wiki` — navigable `wiki/` knowledge base (architecture diagrams, per-module deep dives, glossary, onboarding) with resumable manifest and a two-layer secrets filter. (#100)

### Distribution parity fixes folded in this cycle
- `claude-plugin/` install source now carries the `improve` command row that had drifted out of the distribution `SKILL.md`. (#98)
- Removed v2.1.0 wrapper-CLI leftovers that broke a fresh-clone test run. (#99)
- Command count aligned to 13 across `AGENTS.md`, `marketplace.json`, Codex manifest.

### Version sync (drift corrected)
| File | Before | After |
|------|--------|-------|
| `claude-plugin/.claude-plugin/plugin.json` | 2.1.2 | 2.1.3 |
| `.claude-plugin/marketplace.json` (×2) | 2.1.0 | 2.1.3 |
| `plugins/autoresearch/.codex-plugin/plugin.json` | 2.1.0-codex.0 | 2.1.3-codex.0 |
| `SKILL.md` (all 5 distributions) | 2.1.0 | 2.1.3 |
| README / guide version badges | 2.1.2 | 2.1.3 |

### Verification
- `bash tests/test-hooks.sh` → 105/105 passing.
- All three plugin manifests validate as JSON.
- `docs/project-changelog.md` updated with the v2.1.3 entry.