### PR TITLE
feat(regression): add autoresearch:regression stability gate (14th command)

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.2.0
+version: 2.1.4
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.3
+version: 2.2.0
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration
@@ -29,6 +29,7 @@ version: 2.1.3
 | `$autoresearch probe` | 8 personas interrogate requirements until saturation | 15 |
 | `$autoresearch improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |
 | `$autoresearch evals` | Analyze iteration results: trends, plateaus, regressions | N/A |
+| `$autoresearch regression` | Regression stability gate: baseline vs candidate, verdict STABLE/UNSTABLE | N/A |
 
 ## Universal Flags
 

--- a/.agents/skills/autoresearch/regression.md
+++ b/.agents/skills/autoresearch/regression.md
@@ -1,0 +1,110 @@
+---
+name: autoresearch:regression
+description: "Layered regression stability gate: capture baseline behavior on the base ref, diff the candidate, verdict STABLE/UNSTABLE before you push"
+argument-hint: "[Base: <ref>] [Scope: <glob>] [--select auto|full|affected] [--samples N] [--noise-band %] [--matrix] [--max-runs N] [--baseline-cache] [Baseline: <prebuilt-ref>] [--probe|--no-probe|--probe deep] [--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain]"
+---
+
+EXECUTE IMMEDIATELY.
+
+A regression is a **green→red transition ONLY**. The gate orchestrates the project's OWN test/bench/snapshot/migrate commands (it is a protocol, not a bundled framework), captures baseline behavior in an isolated git worktree, re-runs the candidate, and reports a tiered ship/no-ship verdict.
+
+## Parse Arguments
+
+Extract from $ARGUMENTS:
+- `Base:` or `--base` — base ref to diff against. Default: `git merge-base HEAD main` (else `main`/`master`).
+- `Scope:` or `--scope` — file globs limiting the change surface.
+- `--select auto|full|affected` — test selection (default `auto`). `auto` = use the detected affected-test mapper if available, else FULL suite. Never a silent subset.
+- `--samples N` — SCORE samples/side (default 7). `--noise-band %` — perf tolerance (default 5%).
+- `--matrix` — opt-in matrix axis (OFF by default). `--max-runs N` — ceiling (default 200).
+- `--baseline-cache` (default on) — reuse `baseline/<full-sha>/` by SHA. `Baseline: <prebuilt-ref>` — bypass capture.
+- `--probe` (default) / `--probe deep` / `--no-probe`.
+- `--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain <targets>` and `--<sub>` shorthand.
+- `Iterations:` — repeat-axis count for `--select`/repeat sweeps.
+
+## Setup / Probe-on-launch
+
+1. Auto-detect per-dimension verify commands: `package.json` scripts, `Makefile`, `nx`, migrate config, bench/snapshot/size scripts.
+2. AskUserQuestion (single batch) to confirm detected commands + base ref + which dimensions to run.
+3. **Auto-skip probe** when CI / no-TTY / `--mode autonomous` / complete-config / chained-handoff — log the inferred config instead of asking.
+
+## Classification Phase (first-class, before any differential)
+
+Establish the baseline green-set per dimension, then tag each unit. Match by **test-id first, then path**.
+
+| State | Meaning | Gated? |
+|---|---|---|
+| `regression-eligible` | green on baseline | YES — only green→red counts |
+| `pre-existing` | red→red (already failing) | no — excluded |
+| `new-coverage` | absent→red (brand-new test) | no — new coverage, ungated |
+| `flaky` | nondeterministic on baseline | no — routed to flakiness SCORE |
+| `baseline-unavailable` | dimension never green | no — advisory only |
+
+**Core invariant: red→red, absent→red, and flake→red are NOT regressions.** Run flakiness N× on **both** baseline and candidate; a candidate failure inside the baseline flake-envelope routes to flakiness SCORE, never to a regression. `5/5 green ≠ non-flaky` — detection probability is `1−(1−p)^n` (≈23% at p=5%, n=5); print it.
+
+## Baseline Capture
+
+`git worktree add --detach <full-sha>` (detached SHA — avoids "branch already checked out" when Base==HEAD) → `baseline/<full-sha>/`; `--baseline-cache` reuses by SHA. Then per worktree: `git submodule update --init` + dependency install (lockfile is SHA-pinned so the cache stays sound). Per-dimension **setup tiers**: api-contract = file-diff, no build; functional / integration-e2e / data-migration = full env. On completion or crash: `git worktree remove` + `git worktree prune`. Warn on concurrent index-lock contention. `Baseline: <prebuilt-ref>` bypasses capture.
+
+## Dimension Registry (8)
+
+| Dim | Tier | Compare | Key params |
+|---|---|---|---|
+| functional | HARD | baseline green-set vs candidate; new fail = regression | test cmd, globs |
+| api-contract | HARD | schema/exports diff → breaking? | schema cmd, breaking ruleset |
+| data-migration | HARD | default: up applies clean + idempotent re-apply + app boots/schema valid; schema/rowcount roundtrip opt-in | migrate cmds, fixture, allowlisted DB |
+| integration-e2e | HARD | e2e green-set diff | e2e cmd |
+| flakiness | SCORE | run N× on baseline + candidate, count nondeterministic | runs (def 5), flake-threshold |
+| performance | SCORE | K **independent-process** samples/side, Mann-Whitney U AND effect beyond `max(noise-band%, k·stdev)`, report median delta | bench cmd, samples=7, noise-band=5%, k=2 |
+| resource | SCORE | mem/bundle/size delta vs budget | size cmd, budget |
+| visual-ui | SCORE | containerize render; default `maxDiffPixelRatio` + AA-detection; SSIM = per-page escalation | snapshot cmd, diff-threshold, mask regions |
+
+`--select auto` mapper (`jest --findRelatedTests` fed the changed-file list; `nx affected` project-graph) is **best-effort static-import** — blind to dynamic/runtime/global-setup couplings. The report names the mapper + its blind-spot caveat; a HARD STABLE earned on an affected subset prints "run `--select full` for high-stakes". FULL suite is the correctness default.
+
+- **performance independence:** each sample = an independent process launch (warmups discarded), never an in-process iteration — autocorrelation/GC/thermal otherwise violate Mann-Whitney's independence assumption. At n=7 the test detects only ≳1σ regressions; raise `--samples` for tight gates.
+- **data-migration guard:** opt-in. Before any migration the DB URL MUST pass an **anchored** allowlist — host is exactly `localhost` / `127.0.0.1` / a container or service hostname, OR the database name carries a `_test` / `_ci` suffix. A bare substring (e.g. `test` inside `latest`, `ci` inside `precision`) does **not** qualify. Anything else is refused — ephemeral only, never dev/prod — and even an allowlisted URL requires explicit user confirm before applying. Missing/absent down-migration = forward-only advisory, **never a finding**.
+
+## Differential Loop (per dim × axis × run)
+
+Run candidate verify vs baseline metric → compute `regressed` bool + 0-100 `subscore`. Axes: `diff` (default), `repeat N×`, `full`, `matrix` (opt-in). Log one TSV row per cell.
+
+**--max-runs ceiling:** projected = dims × axes × samples × matrix-cells; if > `--max-runs` (default 200) → warn + require confirm (CI default = abort with message).
+
+## Verdict
+
+- Any HARD `regressed=true` with `classification=eligible` → **UNSTABLE** (green→red hard-blocks).
+- Else `stability_score = Σ(weight × dim_subscore)` over SCORE dims that ran (flakiness .30 / performance .30 / resource .20 / visual .20, renormalized over present dims). **STABLE iff ≥ 95** (`REG_THRESHOLD`/weights overridable).
+- Print the **score math** (per-dim contribution table) + declare **dims-ran vs UNAVAILABLE** — an UNAVAILABLE dimension is always listed, never silently passed.
+
+Backed by `scripts/score-regression.sh verdict <results.tsv>` (exit 0 STABLE / 1 UNSTABLE).
+
+## Hunter (root cause)
+
+On a confirmed HARD regression, auto-engage. Bisect (reuse `debug`) ONLY when the failing case passes a **3/3 reproducibility gate**. SCORE / non-deterministic regressions → differential root-cause + optional `--reason` / `--predict`, no bisect. Non-reproducible → "manual triage" finding.
+
+## --fix Re-gate
+
+`--fix` repairs blocking regressions, max **3 cycles** (`--fix-cycles N`). Each cycle MUST strictly shrink the blocking-set else STOP "fix not converging". Intermediate re-gate scopes to failing+touched dims; the final cycle runs the full battery. No HARD-gate bypass.
+
+## Output
+
+`autoresearch/regression-{YYMMDD}-{HHMM}/` → `regression-results.tsv`, `stability-report.md`, `dimensions/<dim>.md`, `baseline/`, `evals-summary.md` (if `--evals`), `handoff.json`.
+
+TSV header: `# metric_direction: higher_is_better` then
+`iteration\ttimestamp\tdimension\taxis\ttier\tclassification\tbaseline\tcandidate\tdelta\tregressed\tsubscore\tseverity\tstatus\tfile_line\tdescription`.
+
+## Eval Checkpoint (--evals flag)
+
+Interval = floor(max_runs / 3), min 1 (fixed 10 if unbounded); override `--evals-interval N`. Every interval, analyze the results TSV; print trend (up/flat/down) + one-line recommendation. Plateau 3+ checkpoints → recommend early stop. At end → full summary to `evals-summary.md`.
+
+## Chain Handoff
+
+Write `handoff.json` to the output directory: version "2.1.0", source "regression", timestamp,
+`status` ∈ family enum {COMPLETE, CONVERGED, SATURATED, BOUNDED, USER_INTERRUPT, ERROR} (backward-compat with evals/ship consumers),
+`verdict` ∈ {STABLE, UNSTABLE, BASELINE_UNAVAILABLE} + `regression_state` ∈ {REGRESSION_FOUND, REGRESSION_FIXED, none} — `ship` reads `verdict` for the deploy-gate,
+`results_tsv` path, `findings` = blocking regressions (dim, severity, file_line, classification), `config`{base, scope, dims, axes, verdict-math}.
+
+If `--fix` → chain to fix automatically. Invoke next `--chain` target in order; propagate `--evals`. Canonical combo: `--predict --evals --fix --ship` = predict → gate → (hunter on HARD) → fix(≤3) → re-gate → ship iff STABLE (deploy still needs explicit approval).
+
+## Safety
+
+Verify-command screen (no `rm -rf` / `curl|sh`); worktree cleanup + prune on crash; data-migration refuses any non-allowlisted DB URL; probe auto-skips non-interactively; chained `ship` never auto-deploys.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "2.2.0",
+  "version": "2.1.4",
   "description": "Claude Autoresearch \u2014 autonomous goal-directed iteration for Claude Code. 14 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve, regression.",
   "owner": {
     "name": "Udit Goenka",
@@ -11,7 +11,7 @@
     {
       "name": "autoresearch",
       "description": "Autonomous improvement engine. 14 commands with bounded defaults, chain handoff, and adaptive evals checkpoints. 95% token reduction via modular architecture.",
-      "version": "2.2.0",
+      "version": "2.1.4",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "autoresearch",
-  "version": "2.1.3",
-  "description": "Claude Autoresearch \u2014 autonomous goal-directed iteration for Claude Code. 13 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve.",
+  "version": "2.2.0",
+  "description": "Claude Autoresearch \u2014 autonomous goal-directed iteration for Claude Code. 14 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve, regression.",
   "owner": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "autoresearch",
-      "description": "Autonomous improvement engine. 13 commands with bounded defaults, chain handoff, and adaptive evals checkpoints. 95% token reduction via modular architecture.",
-      "version": "2.1.3",
+      "description": "Autonomous improvement engine. 14 commands with bounded defaults, chain handoff, and adaptive evals checkpoints. 95% token reduction via modular architecture.",
+      "version": "2.2.0",
       "author": {
         "name": "Udit Goenka",
         "url": "https://github.com/uditgoenka"

--- a/.claude/commands/autoresearch/regression.md
+++ b/.claude/commands/autoresearch/regression.md
@@ -1,0 +1,110 @@
+---
+name: autoresearch:regression
+description: "Layered regression stability gate: capture baseline behavior on the base ref, diff the candidate, verdict STABLE/UNSTABLE before you push"
+argument-hint: "[Base: <ref>] [Scope: <glob>] [--select auto|full|affected] [--samples N] [--noise-band %] [--matrix] [--max-runs N] [--baseline-cache] [Baseline: <prebuilt-ref>] [--probe|--no-probe|--probe deep] [--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain]"
+---
+
+EXECUTE IMMEDIATELY.
+
+A regression is a **green→red transition ONLY**. The gate orchestrates the project's OWN test/bench/snapshot/migrate commands (it is a protocol, not a bundled framework), captures baseline behavior in an isolated git worktree, re-runs the candidate, and reports a tiered ship/no-ship verdict.
+
+## Parse Arguments
+
+Extract from $ARGUMENTS:
+- `Base:` or `--base` — base ref to diff against. Default: `git merge-base HEAD main` (else `main`/`master`).
+- `Scope:` or `--scope` — file globs limiting the change surface.
+- `--select auto|full|affected` — test selection (default `auto`). `auto` = use the detected affected-test mapper if available, else FULL suite. Never a silent subset.
+- `--samples N` — SCORE samples/side (default 7). `--noise-band %` — perf tolerance (default 5%).
+- `--matrix` — opt-in matrix axis (OFF by default). `--max-runs N` — ceiling (default 200).
+- `--baseline-cache` (default on) — reuse `baseline/<full-sha>/` by SHA. `Baseline: <prebuilt-ref>` — bypass capture.
+- `--probe` (default) / `--probe deep` / `--no-probe`.
+- `--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain <targets>` and `--<sub>` shorthand.
+- `Iterations:` — repeat-axis count for `--select`/repeat sweeps.
+
+## Setup / Probe-on-launch
+
+1. Auto-detect per-dimension verify commands: `package.json` scripts, `Makefile`, `nx`, migrate config, bench/snapshot/size scripts.
+2. AskUserQuestion (single batch) to confirm detected commands + base ref + which dimensions to run.
+3. **Auto-skip probe** when CI / no-TTY / `--mode autonomous` / complete-config / chained-handoff — log the inferred config instead of asking.
+
+## Classification Phase (first-class, before any differential)
+
+Establish the baseline green-set per dimension, then tag each unit. Match by **test-id first, then path**.
+
+| State | Meaning | Gated? |
+|---|---|---|
+| `regression-eligible` | green on baseline | YES — only green→red counts |
+| `pre-existing` | red→red (already failing) | no — excluded |
+| `new-coverage` | absent→red (brand-new test) | no — new coverage, ungated |
+| `flaky` | nondeterministic on baseline | no — routed to flakiness SCORE |
+| `baseline-unavailable` | dimension never green | no — advisory only |
+
+**Core invariant: red→red, absent→red, and flake→red are NOT regressions.** Run flakiness N× on **both** baseline and candidate; a candidate failure inside the baseline flake-envelope routes to flakiness SCORE, never to a regression. `5/5 green ≠ non-flaky` — detection probability is `1−(1−p)^n` (≈23% at p=5%, n=5); print it.
+
+## Baseline Capture
+
+`git worktree add --detach <full-sha>` (detached SHA — avoids "branch already checked out" when Base==HEAD) → `baseline/<full-sha>/`; `--baseline-cache` reuses by SHA. Then per worktree: `git submodule update --init` + dependency install (lockfile is SHA-pinned so the cache stays sound). Per-dimension **setup tiers**: api-contract = file-diff, no build; functional / integration-e2e / data-migration = full env. On completion or crash: `git worktree remove` + `git worktree prune`. Warn on concurrent index-lock contention. `Baseline: <prebuilt-ref>` bypasses capture.
+
+## Dimension Registry (8)
+
+| Dim | Tier | Compare | Key params |
+|---|---|---|---|
+| functional | HARD | baseline green-set vs candidate; new fail = regression | test cmd, globs |
+| api-contract | HARD | schema/exports diff → breaking? | schema cmd, breaking ruleset |
+| data-migration | HARD | default: up applies clean + idempotent re-apply + app boots/schema valid; schema/rowcount roundtrip opt-in | migrate cmds, fixture, allowlisted DB |
+| integration-e2e | HARD | e2e green-set diff | e2e cmd |
+| flakiness | SCORE | run N× on baseline + candidate, count nondeterministic | runs (def 5), flake-threshold |
+| performance | SCORE | K **independent-process** samples/side, Mann-Whitney U AND effect beyond `max(noise-band%, k·stdev)`, report median delta | bench cmd, samples=7, noise-band=5%, k=2 |
+| resource | SCORE | mem/bundle/size delta vs budget | size cmd, budget |
+| visual-ui | SCORE | containerize render; default `maxDiffPixelRatio` + AA-detection; SSIM = per-page escalation | snapshot cmd, diff-threshold, mask regions |
+
+`--select auto` mapper (`jest --findRelatedTests` fed the changed-file list; `nx affected` project-graph) is **best-effort static-import** — blind to dynamic/runtime/global-setup couplings. The report names the mapper + its blind-spot caveat; a HARD STABLE earned on an affected subset prints "run `--select full` for high-stakes". FULL suite is the correctness default.
+
+- **performance independence:** each sample = an independent process launch (warmups discarded), never an in-process iteration — autocorrelation/GC/thermal otherwise violate Mann-Whitney's independence assumption. At n=7 the test detects only ≳1σ regressions; raise `--samples` for tight gates.
+- **data-migration guard:** opt-in. Before any migration the DB URL MUST pass an **anchored** allowlist — host is exactly `localhost` / `127.0.0.1` / a container or service hostname, OR the database name carries a `_test` / `_ci` suffix. A bare substring (e.g. `test` inside `latest`, `ci` inside `precision`) does **not** qualify. Anything else is refused — ephemeral only, never dev/prod — and even an allowlisted URL requires explicit user confirm before applying. Missing/absent down-migration = forward-only advisory, **never a finding**.
+
+## Differential Loop (per dim × axis × run)
+
+Run candidate verify vs baseline metric → compute `regressed` bool + 0-100 `subscore`. Axes: `diff` (default), `repeat N×`, `full`, `matrix` (opt-in). Log one TSV row per cell.
+
+**--max-runs ceiling:** projected = dims × axes × samples × matrix-cells; if > `--max-runs` (default 200) → warn + require confirm (CI default = abort with message).
+
+## Verdict
+
+- Any HARD `regressed=true` with `classification=eligible` → **UNSTABLE** (green→red hard-blocks).
+- Else `stability_score = Σ(weight × dim_subscore)` over SCORE dims that ran (flakiness .30 / performance .30 / resource .20 / visual .20, renormalized over present dims). **STABLE iff ≥ 95** (`REG_THRESHOLD`/weights overridable).
+- Print the **score math** (per-dim contribution table) + declare **dims-ran vs UNAVAILABLE** — an UNAVAILABLE dimension is always listed, never silently passed.
+
+Backed by `scripts/score-regression.sh verdict <results.tsv>` (exit 0 STABLE / 1 UNSTABLE).
+
+## Hunter (root cause)
+
+On a confirmed HARD regression, auto-engage. Bisect (reuse `debug`) ONLY when the failing case passes a **3/3 reproducibility gate**. SCORE / non-deterministic regressions → differential root-cause + optional `--reason` / `--predict`, no bisect. Non-reproducible → "manual triage" finding.
+
+## --fix Re-gate
+
+`--fix` repairs blocking regressions, max **3 cycles** (`--fix-cycles N`). Each cycle MUST strictly shrink the blocking-set else STOP "fix not converging". Intermediate re-gate scopes to failing+touched dims; the final cycle runs the full battery. No HARD-gate bypass.
+
+## Output
+
+`autoresearch/regression-{YYMMDD}-{HHMM}/` → `regression-results.tsv`, `stability-report.md`, `dimensions/<dim>.md`, `baseline/`, `evals-summary.md` (if `--evals`), `handoff.json`.
+
+TSV header: `# metric_direction: higher_is_better` then
+`iteration\ttimestamp\tdimension\taxis\ttier\tclassification\tbaseline\tcandidate\tdelta\tregressed\tsubscore\tseverity\tstatus\tfile_line\tdescription`.
+
+## Eval Checkpoint (--evals flag)
+
+Interval = floor(max_runs / 3), min 1 (fixed 10 if unbounded); override `--evals-interval N`. Every interval, analyze the results TSV; print trend (up/flat/down) + one-line recommendation. Plateau 3+ checkpoints → recommend early stop. At end → full summary to `evals-summary.md`.
+
+## Chain Handoff
+
+Write `handoff.json` to the output directory: version "2.1.0", source "regression", timestamp,
+`status` ∈ family enum {COMPLETE, CONVERGED, SATURATED, BOUNDED, USER_INTERRUPT, ERROR} (backward-compat with evals/ship consumers),
+`verdict` ∈ {STABLE, UNSTABLE, BASELINE_UNAVAILABLE} + `regression_state` ∈ {REGRESSION_FOUND, REGRESSION_FIXED, none} — `ship` reads `verdict` for the deploy-gate,
+`results_tsv` path, `findings` = blocking regressions (dim, severity, file_line, classification), `config`{base, scope, dims, axes, verdict-math}.
+
+If `--fix` → chain to fix automatically. Invoke next `--chain` target in order; propagate `--evals`. Canonical combo: `--predict --evals --fix --ship` = predict → gate → (hunter on HARD) → fix(≤3) → re-gate → ship iff STABLE (deploy still needs explicit approval).
+
+## Safety
+
+Verify-command screen (no `rm -rf` / `curl|sh`); worktree cleanup + prune on crash; data-migration refuses any non-allowlisted DB URL; probe auto-skips non-interactively; chained `ship` never auto-deploys.

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.2.0
+version: 2.1.4
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.3
+version: 2.2.0
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration
@@ -29,6 +29,7 @@ version: 2.1.3
 | `/autoresearch:probe` | 8 personas interrogate requirements until saturation | 15 |
 | `/autoresearch:improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |
 | `/autoresearch:evals` | Analyze iteration results: trends, plateaus, regressions | N/A |
+| `/autoresearch:regression` | Regression stability gate: baseline vs candidate, verdict STABLE/UNSTABLE | N/A |
 
 ## Universal Flags
 

--- a/.opencode/commands/autoresearch_regression.md
+++ b/.opencode/commands/autoresearch_regression.md
@@ -1,0 +1,110 @@
+---
+name: autoresearch:regression
+description: "Layered regression stability gate: capture baseline behavior on the base ref, diff the candidate, verdict STABLE/UNSTABLE before you push"
+argument-hint: "[Base: <ref>] [Scope: <glob>] [--select auto|full|affected] [--samples N] [--noise-band %] [--matrix] [--max-runs N] [--baseline-cache] [Baseline: <prebuilt-ref>] [--probe|--no-probe|--probe deep] [--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain]"
+---
+
+EXECUTE IMMEDIATELY.
+
+A regression is a **green→red transition ONLY**. The gate orchestrates the project's OWN test/bench/snapshot/migrate commands (it is a protocol, not a bundled framework), captures baseline behavior in an isolated git worktree, re-runs the candidate, and reports a tiered ship/no-ship verdict.
+
+## Parse Arguments
+
+Extract from $ARGUMENTS:
+- `Base:` or `--base` — base ref to diff against. Default: `git merge-base HEAD main` (else `main`/`master`).
+- `Scope:` or `--scope` — file globs limiting the change surface.
+- `--select auto|full|affected` — test selection (default `auto`). `auto` = use the detected affected-test mapper if available, else FULL suite. Never a silent subset.
+- `--samples N` — SCORE samples/side (default 7). `--noise-band %` — perf tolerance (default 5%).
+- `--matrix` — opt-in matrix axis (OFF by default). `--max-runs N` — ceiling (default 200).
+- `--baseline-cache` (default on) — reuse `baseline/<full-sha>/` by SHA. `Baseline: <prebuilt-ref>` — bypass capture.
+- `--probe` (default) / `--probe deep` / `--no-probe`.
+- `--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain <targets>` and `--<sub>` shorthand.
+- `Iterations:` — repeat-axis count for `--select`/repeat sweeps.
+
+## Setup / Probe-on-launch
+
+1. Auto-detect per-dimension verify commands: `package.json` scripts, `Makefile`, `nx`, migrate config, bench/snapshot/size scripts.
+2. AskUserQuestion (single batch) to confirm detected commands + base ref + which dimensions to run.
+3. **Auto-skip probe** when CI / no-TTY / `--mode autonomous` / complete-config / chained-handoff — log the inferred config instead of asking.
+
+## Classification Phase (first-class, before any differential)
+
+Establish the baseline green-set per dimension, then tag each unit. Match by **test-id first, then path**.
+
+| State | Meaning | Gated? |
+|---|---|---|
+| `regression-eligible` | green on baseline | YES — only green→red counts |
+| `pre-existing` | red→red (already failing) | no — excluded |
+| `new-coverage` | absent→red (brand-new test) | no — new coverage, ungated |
+| `flaky` | nondeterministic on baseline | no — routed to flakiness SCORE |
+| `baseline-unavailable` | dimension never green | no — advisory only |
+
+**Core invariant: red→red, absent→red, and flake→red are NOT regressions.** Run flakiness N× on **both** baseline and candidate; a candidate failure inside the baseline flake-envelope routes to flakiness SCORE, never to a regression. `5/5 green ≠ non-flaky` — detection probability is `1−(1−p)^n` (≈23% at p=5%, n=5); print it.
+
+## Baseline Capture
+
+`git worktree add --detach <full-sha>` (detached SHA — avoids "branch already checked out" when Base==HEAD) → `baseline/<full-sha>/`; `--baseline-cache` reuses by SHA. Then per worktree: `git submodule update --init` + dependency install (lockfile is SHA-pinned so the cache stays sound). Per-dimension **setup tiers**: api-contract = file-diff, no build; functional / integration-e2e / data-migration = full env. On completion or crash: `git worktree remove` + `git worktree prune`. Warn on concurrent index-lock contention. `Baseline: <prebuilt-ref>` bypasses capture.
+
+## Dimension Registry (8)
+
+| Dim | Tier | Compare | Key params |
+|---|---|---|---|
+| functional | HARD | baseline green-set vs candidate; new fail = regression | test cmd, globs |
+| api-contract | HARD | schema/exports diff → breaking? | schema cmd, breaking ruleset |
+| data-migration | HARD | default: up applies clean + idempotent re-apply + app boots/schema valid; schema/rowcount roundtrip opt-in | migrate cmds, fixture, allowlisted DB |
+| integration-e2e | HARD | e2e green-set diff | e2e cmd |
+| flakiness | SCORE | run N× on baseline + candidate, count nondeterministic | runs (def 5), flake-threshold |
+| performance | SCORE | K **independent-process** samples/side, Mann-Whitney U AND effect beyond `max(noise-band%, k·stdev)`, report median delta | bench cmd, samples=7, noise-band=5%, k=2 |
+| resource | SCORE | mem/bundle/size delta vs budget | size cmd, budget |
+| visual-ui | SCORE | containerize render; default `maxDiffPixelRatio` + AA-detection; SSIM = per-page escalation | snapshot cmd, diff-threshold, mask regions |
+
+`--select auto` mapper (`jest --findRelatedTests` fed the changed-file list; `nx affected` project-graph) is **best-effort static-import** — blind to dynamic/runtime/global-setup couplings. The report names the mapper + its blind-spot caveat; a HARD STABLE earned on an affected subset prints "run `--select full` for high-stakes". FULL suite is the correctness default.
+
+- **performance independence:** each sample = an independent process launch (warmups discarded), never an in-process iteration — autocorrelation/GC/thermal otherwise violate Mann-Whitney's independence assumption. At n=7 the test detects only ≳1σ regressions; raise `--samples` for tight gates.
+- **data-migration guard:** opt-in. Before any migration the DB URL MUST pass an **anchored** allowlist — host is exactly `localhost` / `127.0.0.1` / a container or service hostname, OR the database name carries a `_test` / `_ci` suffix. A bare substring (e.g. `test` inside `latest`, `ci` inside `precision`) does **not** qualify. Anything else is refused — ephemeral only, never dev/prod — and even an allowlisted URL requires explicit user confirm before applying. Missing/absent down-migration = forward-only advisory, **never a finding**.
+
+## Differential Loop (per dim × axis × run)
+
+Run candidate verify vs baseline metric → compute `regressed` bool + 0-100 `subscore`. Axes: `diff` (default), `repeat N×`, `full`, `matrix` (opt-in). Log one TSV row per cell.
+
+**--max-runs ceiling:** projected = dims × axes × samples × matrix-cells; if > `--max-runs` (default 200) → warn + require confirm (CI default = abort with message).
+
+## Verdict
+
+- Any HARD `regressed=true` with `classification=eligible` → **UNSTABLE** (green→red hard-blocks).
+- Else `stability_score = Σ(weight × dim_subscore)` over SCORE dims that ran (flakiness .30 / performance .30 / resource .20 / visual .20, renormalized over present dims). **STABLE iff ≥ 95** (`REG_THRESHOLD`/weights overridable).
+- Print the **score math** (per-dim contribution table) + declare **dims-ran vs UNAVAILABLE** — an UNAVAILABLE dimension is always listed, never silently passed.
+
+Backed by `scripts/score-regression.sh verdict <results.tsv>` (exit 0 STABLE / 1 UNSTABLE).
+
+## Hunter (root cause)
+
+On a confirmed HARD regression, auto-engage. Bisect (reuse `debug`) ONLY when the failing case passes a **3/3 reproducibility gate**. SCORE / non-deterministic regressions → differential root-cause + optional `--reason` / `--predict`, no bisect. Non-reproducible → "manual triage" finding.
+
+## --fix Re-gate
+
+`--fix` repairs blocking regressions, max **3 cycles** (`--fix-cycles N`). Each cycle MUST strictly shrink the blocking-set else STOP "fix not converging". Intermediate re-gate scopes to failing+touched dims; the final cycle runs the full battery. No HARD-gate bypass.
+
+## Output
+
+`autoresearch/regression-{YYMMDD}-{HHMM}/` → `regression-results.tsv`, `stability-report.md`, `dimensions/<dim>.md`, `baseline/`, `evals-summary.md` (if `--evals`), `handoff.json`.
+
+TSV header: `# metric_direction: higher_is_better` then
+`iteration\ttimestamp\tdimension\taxis\ttier\tclassification\tbaseline\tcandidate\tdelta\tregressed\tsubscore\tseverity\tstatus\tfile_line\tdescription`.
+
+## Eval Checkpoint (--evals flag)
+
+Interval = floor(max_runs / 3), min 1 (fixed 10 if unbounded); override `--evals-interval N`. Every interval, analyze the results TSV; print trend (up/flat/down) + one-line recommendation. Plateau 3+ checkpoints → recommend early stop. At end → full summary to `evals-summary.md`.
+
+## Chain Handoff
+
+Write `handoff.json` to the output directory: version "2.1.0", source "regression", timestamp,
+`status` ∈ family enum {COMPLETE, CONVERGED, SATURATED, BOUNDED, USER_INTERRUPT, ERROR} (backward-compat with evals/ship consumers),
+`verdict` ∈ {STABLE, UNSTABLE, BASELINE_UNAVAILABLE} + `regression_state` ∈ {REGRESSION_FOUND, REGRESSION_FIXED, none} — `ship` reads `verdict` for the deploy-gate,
+`results_tsv` path, `findings` = blocking regressions (dim, severity, file_line, classification), `config`{base, scope, dims, axes, verdict-math}.
+
+If `--fix` → chain to fix automatically. Invoke next `--chain` target in order; propagate `--evals`. Canonical combo: `--predict --evals --fix --ship` = predict → gate → (hunter on HARD) → fix(≤3) → re-gate → ship iff STABLE (deploy still needs explicit approval).
+
+## Safety
+
+Verify-command screen (no `rm -rf` / `curl|sh`); worktree cleanup + prune on crash; data-migration refuses any non-allowlisted DB URL; probe auto-skips non-interactively; chained `ship` never auto-deploys.

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.2.0
+version: 2.1.4
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/.opencode/skills/autoresearch/SKILL.md
+++ b/.opencode/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.3
+version: 2.2.0
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration
@@ -29,6 +29,7 @@ version: 2.1.3
 | `/autoresearch_probe` | 8 personas interrogate requirements until saturation | 15 |
 | `/autoresearch_improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |
 | `/autoresearch_evals` | Analyze iteration results: trends, plateaus, regressions | N/A |
+| `/autoresearch_regression` | Regression stability gate: baseline vs candidate, verdict STABLE/UNSTABLE | N/A |
 
 ## Universal Flags
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Autonomous goal-directed iteration based on [Karpathy's autoresearch](https://gi
 /plugin install autoresearch@autoresearch
 ```
 
-Restart session after install. All 13 commands become available as `/autoresearch` and `/autoresearch:<subcommand>`.
+Restart session after install. All 14 commands become available as `/autoresearch` and `/autoresearch:<subcommand>`.
 
 ### Codex (plugin)
 

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -14,7 +14,7 @@
 
 In March 2026, **[Andrej Karpathy](https://github.com/karpathy)** released [autoresearch](https://github.com/karpathy/autoresearch) — a 630-line Python script that let AI agents autonomously optimize a GPT language model overnight. In 2 days, a single agent ran **700 experiments**, discovered **20 optimizations**, and achieved an **11% speedup** on already-optimized code. The repo hit 26,000 GitHub stars in under a week.
 
-**[Claude Autoresearch](https://github.com/uditgoenka/autoresearch)** by **[Udit Goenka](https://udit.co)** takes Karpathy's core principles — constraint, mechanical metric, autonomous iteration — and generalizes them into a **Claude Code skill system** with 13 commands that work on **any domain**: code, content, marketing, sales, security, DevOps, HR, or anything with a measurable number.
+**[Claude Autoresearch](https://github.com/uditgoenka/autoresearch)** by **[Udit Goenka](https://udit.co)** takes Karpathy's core principles — constraint, mechanical metric, autonomous iteration — and generalizes them into a **Claude Code skill system** with 14 commands that work on **any domain**: code, content, marketing, sales, security, DevOps, HR, or anything with a measurable number.
 
 The philosophy is the same. The scope is radically different.
 
@@ -28,12 +28,12 @@ The philosophy is the same. The scope is radically different.
 | **Created by** | Andrej Karpathy (ex-Tesla AI, OpenAI) | Udit Goenka (AI Product Expert, Founder) |
 | **Released** | March 2026 | March 2026 |
 | **Language** | Python (PyTorch) | Markdown (Claude Code skill system) |
-| **LOC** | ~630 (train.py) | ~1,600 across 13 self-contained command files + routing table |
+| **LOC** | ~630 (train.py) | ~1,750 across 14 self-contained command files + routing table |
 | **Runtime** | Python + NVIDIA GPU + CUDA | Claude Code (any OS, any project, any language) |
 | **Domain** | ML model training only | Any domain with a measurable metric |
 | **Metric** | val_bpb (validation bits per byte) | Any mechanical metric you define |
 | **Scope** | Single file (train.py) | Any glob pattern (e.g., `src/**/*.ts`) |
-| **Commands** | 1 (run the script) | 13 subcommands + flags |
+| **Commands** | 1 (run the script) | 14 subcommands + flags |
 | **Setup** | Manual (edit program.md) | Interactive wizard (`/autoresearch:plan`) |
 | **Hardware** | Requires NVIDIA GPU (H100/A100/RTX) | No special hardware — runs wherever Claude Code runs |
 | **Cost** | GPU compute ($2-5/hour for H100) | Claude API tokens only |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) —
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
 [![OpenCode](https://img.shields.io/badge/OpenCode-Skill-purple)](https://opencode.ai)
 [![Codex](https://img.shields.io/badge/Codex-Skill-green?logo=openai&logoColor=white)](https://developers.openai.com/codex)
-[![Version](https://img.shields.io/badge/version-2.2.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-2.1.4-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) —
 [![Claude Code Skill](https://img.shields.io/badge/Claude_Code-Skill-blue?logo=anthropic&logoColor=white)](https://docs.anthropic.com/en/docs/claude-code)
 [![OpenCode](https://img.shields.io/badge/OpenCode-Skill-purple)](https://opencode.ai)
 [![Codex](https://img.shields.io/badge/Codex-Skill-green?logo=openai&logoColor=white)](https://developers.openai.com/codex)
-[![Version](https://img.shields.io/badge/version-2.1.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-2.2.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 [![Based on](https://img.shields.io/badge/Based_on-Karpathy's_Autoresearch-orange)](https://github.com/karpathy/autoresearch)
@@ -22,7 +22,7 @@ Based on [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) —
 
 *You don't need AGI. You need a goal, a metric, and a loop that never quits.*
 
-**Supports Claude Code, OpenCode, and OpenAI Codex. 13 commands. 9 safety hooks. 95% fewer tokens per invocation.**
+**Supports Claude Code, OpenCode, and OpenAI Codex. 14 commands. 9 safety hooks. 95% fewer tokens per invocation.**
 
 <br>
 
@@ -172,12 +172,13 @@ See [guide/hooks.md](guide/hooks.md) for full reference.
 | `/autoresearch:probe` | 8 personas interrogate requirements | 15 |
 | `/autoresearch:improve` | Research ICP, discover improvements, generate PRDs | 15 |
 | `/autoresearch:evals` | Analyze iteration results: trends, plateaus | one-shot |
+| `/autoresearch:regression` | Stability gate: baseline vs candidate, verdict STABLE/UNSTABLE | one-shot |
 
 **Universal flags:** `Iterations: N`, `Iterations: unlimited`, `--evals`, `--evals-interval N`, `--chain <targets>`, `--<subcommand>` shorthand.
 
 **All commands use interactive setup when invoked without arguments.** Just type the command — the agent asks for what it needs with smart defaults based on your codebase.
 
-> **OpenCode users:** Commands use underscore naming (`/autoresearch_debug`, `/autoresearch_fix`, etc.). All 13 commands available.
+> **OpenCode users:** Commands use underscore naming (`/autoresearch_debug`, `/autoresearch_fix`, etc.). All 14 commands available.
 >
 > **Codex users:** Invoke via `$autoresearch` mention syntax. Subcommands are keywords: `$autoresearch debug`, `$autoresearch plan`, etc.
 
@@ -209,6 +210,8 @@ See [guide/hooks.md](guide/hooks.md) for full reference.
 | Probe requirements then research improvements | `/autoresearch:probe --improve` |
 | Analyze trends and plateaus across past runs | `/autoresearch:evals` |
 | Check if a run has stalled | `/autoresearch:evals --file *-results.tsv` |
+| Verify a change won't regress before pushing | `/autoresearch:regression` |
+| Gate a PR: predict, fix, re-gate, then ship | `/autoresearch:regression --predict --fix --ship` |
 
 ---
 
@@ -222,7 +225,7 @@ See [guide/hooks.md](guide/hooks.md) for full reference.
 npx skills add uditgoenka/autoresearch
 ```
 
-All 13 commands are available after restarting Claude Code.
+All 14 commands are available after restarting Claude Code.
 
 **Option B — Plugin install:**
 
@@ -287,7 +290,7 @@ cp -r autoresearch/.opencode/skills/autoresearch ~/.config/opencode/skills/autor
 cp autoresearch/.opencode/commands/autoresearch*.md ~/.config/opencode/commands/
 ```
 
-> All 13 commands available as `/autoresearch_debug`, `/autoresearch_fix`, `/autoresearch_improve`, etc.
+> All 14 commands available as `/autoresearch_debug`, `/autoresearch_fix`, `/autoresearch_improve`, etc.
 
 ### Codex Quick Start
 
@@ -572,6 +575,36 @@ Prints a checkpoint report every 10 iterations without interrupting the loop.
 
 ---
 
+## /autoresearch:regression — Stability Gate
+
+Before you push, prove the change didn't break what already worked. Captures baseline behavior from a `git worktree` of the base ref, diffs the candidate across **8 dimensions**, and emits a single **STABLE / UNSTABLE** verdict.
+
+```
+/autoresearch:regression --predict --evals --fix --ship
+```
+
+**Core invariant:** a regression is a **green→red transition only**. Pre-existing failures (red→red), new tests (absent→red), and flaky tests (flake→red) are classified and excluded — never counted as regressions.
+
+**Tiered verdict:**
+- **HARD gate** (any green→red = UNSTABLE): `functional`, `api-contract`, `data-migration`, `integration-e2e`
+- **SCORE** (0–100, noise-tolerant, weighted; UNSTABLE below threshold 95): `flakiness` .30, `performance` .30, `resource` .20, `visual-ui` .20
+
+| Flag | Purpose |
+|------|---------|
+| `--select auto` | Use detected affected-test mapper (jest `--findRelatedTests`, nx affected) else FULL suite — never a silent subset |
+| `--samples N` / `--noise-band %` | Tune the perf statistical gate (default 7 samples/side, Mann–Whitney U) |
+| `--fix` / `--fix-cycles N` | Re-gate after fixing; each cycle must strictly shrink the blocking-set (max 3) |
+| `--predict` | Pre-empt likely regressions before the gate runs |
+| `--reason` | Adversarial root-cause when a regression's cause is ambiguous |
+| `--debug` | Force the bisect Hunter (HARD dims passing 3/3 reproduction) |
+| `--max-runs N` | Ceiling on dims×axes×samples×cells (warn+confirm past 200) |
+
+**Output:** Creates `regression/{date}-{slug}/` with regression-results.tsv, stability-report.md, dimensions/<dim>.md, baseline/, evals-summary.md, handoff.json.
+
+> **data-migration is hard-guarded:** opt-in, and refuses any DB URL that isn't ephemeral/allowlisted (`*test*`, `*ci*`, container). Migrations are forward-only by default.
+
+---
+
 ## Guard — Prevent Regressions
 
 When optimizing a metric, the loop might break existing behavior. **Guard** is an optional safety net.
@@ -641,7 +674,7 @@ autoresearch/
 │   │       └── reason-judge-protocol.md           ← Adversarial refinement loop
 │   └── commands/
 │       ├── autoresearch.md                        ← Core loop (self-contained, ~100 lines)
-│       └── autoresearch/                          ← 12 subcommand files (self-contained)
+│       └── autoresearch/                          ← 13 subcommand files (self-contained)
 │           ├── plan.md
 │           ├── debug.md
 │           ├── fix.md
@@ -653,10 +686,11 @@ autoresearch/
 │           ├── reason.md
 │           ├── improve.md
 │           ├── probe.md
-│           └── evals.md
+│           ├── evals.md
+│           └── regression.md
 ├── .opencode/                                     ← OpenCode port (via transform.sh)
 │   ├── skills/autoresearch/
-│   └── commands/                                  ← 13 command files (autoresearch_*.md)
+│   └── commands/                                  ← 14 command files (autoresearch_*.md)
 ├── .agents/                                       ← Codex port (via transform.sh)
 │   └── skills/autoresearch/
 ├── plugins/                                       ← Codex plugin metadata
@@ -684,7 +718,7 @@ A: Point it at any `*-results.tsv` file from a previous run. It reports trends, 
 A: Yes. Any language, framework, or domain. Install via plugin (Claude Code), installer script, or manual copy.
 
 **Q: Does this work with OpenCode?**
-A: Yes. Run `./scripts/install.sh --opencode --global` or manually copy `.opencode/` files. Commands use underscore naming (`/autoresearch_debug`, `/autoresearch_evals`, etc.). All 13 commands available.
+A: Yes. Run `./scripts/install.sh --opencode --global` or manually copy `.opencode/` files. Commands use underscore naming (`/autoresearch_debug`, `/autoresearch_evals`, etc.). All 14 commands available.
 
 **Q: Does this work with OpenAI Codex?**
 A: Yes. Run `./scripts/install.sh --codex --global` or copy `.agents/skills/autoresearch/` to `~/.codex/skills/autoresearch`. Invoke via `$autoresearch` mention syntax.

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
   "description": "Autonomous improvement engine. 14 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, improve, evals, regression.",
-  "version": "2.2.0",
+  "version": "2.1.4",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
-  "description": "Autonomous improvement engine. 13 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, improve, evals.",
-  "version": "2.1.3",
+  "description": "Autonomous improvement engine. 14 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, improve, evals, regression.",
+  "version": "2.2.0",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"

--- a/claude-plugin/commands/autoresearch/regression.md
+++ b/claude-plugin/commands/autoresearch/regression.md
@@ -1,0 +1,110 @@
+---
+name: autoresearch:regression
+description: "Layered regression stability gate: capture baseline behavior on the base ref, diff the candidate, verdict STABLE/UNSTABLE before you push"
+argument-hint: "[Base: <ref>] [Scope: <glob>] [--select auto|full|affected] [--samples N] [--noise-band %] [--matrix] [--max-runs N] [--baseline-cache] [Baseline: <prebuilt-ref>] [--probe|--no-probe|--probe deep] [--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain]"
+---
+
+EXECUTE IMMEDIATELY.
+
+A regression is a **green→red transition ONLY**. The gate orchestrates the project's OWN test/bench/snapshot/migrate commands (it is a protocol, not a bundled framework), captures baseline behavior in an isolated git worktree, re-runs the candidate, and reports a tiered ship/no-ship verdict.
+
+## Parse Arguments
+
+Extract from $ARGUMENTS:
+- `Base:` or `--base` — base ref to diff against. Default: `git merge-base HEAD main` (else `main`/`master`).
+- `Scope:` or `--scope` — file globs limiting the change surface.
+- `--select auto|full|affected` — test selection (default `auto`). `auto` = use the detected affected-test mapper if available, else FULL suite. Never a silent subset.
+- `--samples N` — SCORE samples/side (default 7). `--noise-band %` — perf tolerance (default 5%).
+- `--matrix` — opt-in matrix axis (OFF by default). `--max-runs N` — ceiling (default 200).
+- `--baseline-cache` (default on) — reuse `baseline/<full-sha>/` by SHA. `Baseline: <prebuilt-ref>` — bypass capture.
+- `--probe` (default) / `--probe deep` / `--no-probe`.
+- `--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain <targets>` and `--<sub>` shorthand.
+- `Iterations:` — repeat-axis count for `--select`/repeat sweeps.
+
+## Setup / Probe-on-launch
+
+1. Auto-detect per-dimension verify commands: `package.json` scripts, `Makefile`, `nx`, migrate config, bench/snapshot/size scripts.
+2. AskUserQuestion (single batch) to confirm detected commands + base ref + which dimensions to run.
+3. **Auto-skip probe** when CI / no-TTY / `--mode autonomous` / complete-config / chained-handoff — log the inferred config instead of asking.
+
+## Classification Phase (first-class, before any differential)
+
+Establish the baseline green-set per dimension, then tag each unit. Match by **test-id first, then path**.
+
+| State | Meaning | Gated? |
+|---|---|---|
+| `regression-eligible` | green on baseline | YES — only green→red counts |
+| `pre-existing` | red→red (already failing) | no — excluded |
+| `new-coverage` | absent→red (brand-new test) | no — new coverage, ungated |
+| `flaky` | nondeterministic on baseline | no — routed to flakiness SCORE |
+| `baseline-unavailable` | dimension never green | no — advisory only |
+
+**Core invariant: red→red, absent→red, and flake→red are NOT regressions.** Run flakiness N× on **both** baseline and candidate; a candidate failure inside the baseline flake-envelope routes to flakiness SCORE, never to a regression. `5/5 green ≠ non-flaky` — detection probability is `1−(1−p)^n` (≈23% at p=5%, n=5); print it.
+
+## Baseline Capture
+
+`git worktree add --detach <full-sha>` (detached SHA — avoids "branch already checked out" when Base==HEAD) → `baseline/<full-sha>/`; `--baseline-cache` reuses by SHA. Then per worktree: `git submodule update --init` + dependency install (lockfile is SHA-pinned so the cache stays sound). Per-dimension **setup tiers**: api-contract = file-diff, no build; functional / integration-e2e / data-migration = full env. On completion or crash: `git worktree remove` + `git worktree prune`. Warn on concurrent index-lock contention. `Baseline: <prebuilt-ref>` bypasses capture.
+
+## Dimension Registry (8)
+
+| Dim | Tier | Compare | Key params |
+|---|---|---|---|
+| functional | HARD | baseline green-set vs candidate; new fail = regression | test cmd, globs |
+| api-contract | HARD | schema/exports diff → breaking? | schema cmd, breaking ruleset |
+| data-migration | HARD | default: up applies clean + idempotent re-apply + app boots/schema valid; schema/rowcount roundtrip opt-in | migrate cmds, fixture, allowlisted DB |
+| integration-e2e | HARD | e2e green-set diff | e2e cmd |
+| flakiness | SCORE | run N× on baseline + candidate, count nondeterministic | runs (def 5), flake-threshold |
+| performance | SCORE | K **independent-process** samples/side, Mann-Whitney U AND effect beyond `max(noise-band%, k·stdev)`, report median delta | bench cmd, samples=7, noise-band=5%, k=2 |
+| resource | SCORE | mem/bundle/size delta vs budget | size cmd, budget |
+| visual-ui | SCORE | containerize render; default `maxDiffPixelRatio` + AA-detection; SSIM = per-page escalation | snapshot cmd, diff-threshold, mask regions |
+
+`--select auto` mapper (`jest --findRelatedTests` fed the changed-file list; `nx affected` project-graph) is **best-effort static-import** — blind to dynamic/runtime/global-setup couplings. The report names the mapper + its blind-spot caveat; a HARD STABLE earned on an affected subset prints "run `--select full` for high-stakes". FULL suite is the correctness default.
+
+- **performance independence:** each sample = an independent process launch (warmups discarded), never an in-process iteration — autocorrelation/GC/thermal otherwise violate Mann-Whitney's independence assumption. At n=7 the test detects only ≳1σ regressions; raise `--samples` for tight gates.
+- **data-migration guard:** opt-in. Before any migration the DB URL MUST pass an **anchored** allowlist — host is exactly `localhost` / `127.0.0.1` / a container or service hostname, OR the database name carries a `_test` / `_ci` suffix. A bare substring (e.g. `test` inside `latest`, `ci` inside `precision`) does **not** qualify. Anything else is refused — ephemeral only, never dev/prod — and even an allowlisted URL requires explicit user confirm before applying. Missing/absent down-migration = forward-only advisory, **never a finding**.
+
+## Differential Loop (per dim × axis × run)
+
+Run candidate verify vs baseline metric → compute `regressed` bool + 0-100 `subscore`. Axes: `diff` (default), `repeat N×`, `full`, `matrix` (opt-in). Log one TSV row per cell.
+
+**--max-runs ceiling:** projected = dims × axes × samples × matrix-cells; if > `--max-runs` (default 200) → warn + require confirm (CI default = abort with message).
+
+## Verdict
+
+- Any HARD `regressed=true` with `classification=eligible` → **UNSTABLE** (green→red hard-blocks).
+- Else `stability_score = Σ(weight × dim_subscore)` over SCORE dims that ran (flakiness .30 / performance .30 / resource .20 / visual .20, renormalized over present dims). **STABLE iff ≥ 95** (`REG_THRESHOLD`/weights overridable).
+- Print the **score math** (per-dim contribution table) + declare **dims-ran vs UNAVAILABLE** — an UNAVAILABLE dimension is always listed, never silently passed.
+
+Backed by `scripts/score-regression.sh verdict <results.tsv>` (exit 0 STABLE / 1 UNSTABLE).
+
+## Hunter (root cause)
+
+On a confirmed HARD regression, auto-engage. Bisect (reuse `debug`) ONLY when the failing case passes a **3/3 reproducibility gate**. SCORE / non-deterministic regressions → differential root-cause + optional `--reason` / `--predict`, no bisect. Non-reproducible → "manual triage" finding.
+
+## --fix Re-gate
+
+`--fix` repairs blocking regressions, max **3 cycles** (`--fix-cycles N`). Each cycle MUST strictly shrink the blocking-set else STOP "fix not converging". Intermediate re-gate scopes to failing+touched dims; the final cycle runs the full battery. No HARD-gate bypass.
+
+## Output
+
+`autoresearch/regression-{YYMMDD}-{HHMM}/` → `regression-results.tsv`, `stability-report.md`, `dimensions/<dim>.md`, `baseline/`, `evals-summary.md` (if `--evals`), `handoff.json`.
+
+TSV header: `# metric_direction: higher_is_better` then
+`iteration\ttimestamp\tdimension\taxis\ttier\tclassification\tbaseline\tcandidate\tdelta\tregressed\tsubscore\tseverity\tstatus\tfile_line\tdescription`.
+
+## Eval Checkpoint (--evals flag)
+
+Interval = floor(max_runs / 3), min 1 (fixed 10 if unbounded); override `--evals-interval N`. Every interval, analyze the results TSV; print trend (up/flat/down) + one-line recommendation. Plateau 3+ checkpoints → recommend early stop. At end → full summary to `evals-summary.md`.
+
+## Chain Handoff
+
+Write `handoff.json` to the output directory: version "2.1.0", source "regression", timestamp,
+`status` ∈ family enum {COMPLETE, CONVERGED, SATURATED, BOUNDED, USER_INTERRUPT, ERROR} (backward-compat with evals/ship consumers),
+`verdict` ∈ {STABLE, UNSTABLE, BASELINE_UNAVAILABLE} + `regression_state` ∈ {REGRESSION_FOUND, REGRESSION_FIXED, none} — `ship` reads `verdict` for the deploy-gate,
+`results_tsv` path, `findings` = blocking regressions (dim, severity, file_line, classification), `config`{base, scope, dims, axes, verdict-math}.
+
+If `--fix` → chain to fix automatically. Invoke next `--chain` target in order; propagate `--evals`. Canonical combo: `--predict --evals --fix --ship` = predict → gate → (hunter on HARD) → fix(≤3) → re-gate → ship iff STABLE (deploy still needs explicit approval).
+
+## Safety
+
+Verify-command screen (no `rm -rf` / `curl|sh`); worktree cleanup + prune on crash; data-migration refuses any non-allowlisted DB URL; probe auto-skips non-interactively; chained `ship` never auto-deploys.

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.2.0
+version: 2.1.4
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/claude-plugin/skills/autoresearch/SKILL.md
+++ b/claude-plugin/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.3
+version: 2.2.0
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration
@@ -29,6 +29,7 @@ version: 2.1.3
 | `/autoresearch:probe` | 8 personas interrogate requirements until saturation | 15 |
 | `/autoresearch:improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |
 | `/autoresearch:evals` | Analyze iteration results: trends, plateaus, regressions | N/A |
+| `/autoresearch:regression` | Regression stability gate: baseline vs candidate, verdict STABLE/UNSTABLE | N/A |
 
 ## Universal Flags
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -8,7 +8,7 @@ Autoresearch v2.1.0 ships as a modular, multi-platform autonomous iteration fram
 
 | Directory | Purpose | Primary Types |
 |-----------|---------|---------------|
-| `.claude/commands/` | Core loop + 12 subcommand files (self-contained) | `.md` |
+| `.claude/commands/` | Core loop + 13 subcommand files (self-contained) | `.md` |
 | `.claude/skills/autoresearch/` | Thin routing SKILL.md + 3 reference files | `.md` |
 | `.opencode/commands/` | OpenCode distribution (underscore naming) | `.md` |
 | `.opencode/skills/autoresearch/` | OpenCode skill + reference copies | `.md` |

--- a/docs/development-roadmap.md
+++ b/docs/development-roadmap.md
@@ -65,7 +65,12 @@ Strategic milestones and feature development phases for autoresearch.
 
 ## Current Phase
 
-### Phase 9: Stabilization + Community (In Progress)
+### Phase 9: Regression Stability Gate + Stabilization — 2026-06-19 (v2.2.0)
+- `/autoresearch:regression` — layered stability gate, 14th family member
+  - 8 dimensions, tiered HARD/SCORE verdict, green→red classification invariant
+  - git-worktree baseline cache (SHA-keyed), statistical perf gate (Mann–Whitney U), hard-guarded forward-only data-migration
+  - `scripts/score-regression.sh` (rubric + verdict) + `tests/test-regression.sh` (43 assertions, 9 golden fixtures)
+  - Subcommand count: 13 → 14
 - Guide updates reflecting v2.2.0 command file structure
 - Scenario guide coverage for evals, improve, and chain workflows
 - Community contributions and bug reports

--- a/docs/development-roadmap.md
+++ b/docs/development-roadmap.md
@@ -51,8 +51,6 @@ Strategic milestones and feature development phases for autoresearch.
 - `--evals` / `--evals-interval` flags on all looping commands
 - ~95% token reduction per invocation
 
-## Current Phase
-
 ### Phase 8: Hook System + Product Improvement — 2026-05-22 (v2.1.1 / v2.2.0)
 - 9-hook safety system (v2.1.1)
 - `/autoresearch:improve` — product improvement research + PRD generation (v2.2.0)
@@ -65,13 +63,13 @@ Strategic milestones and feature development phases for autoresearch.
 
 ## Current Phase
 
-### Phase 9: Regression Stability Gate + Stabilization — 2026-06-19 (v2.2.0)
+### Phase 9: Regression Stability Gate + Stabilization — 2026-06-19 (v2.1.4)
 - `/autoresearch:regression` — layered stability gate, 14th family member
   - 8 dimensions, tiered HARD/SCORE verdict, green→red classification invariant
   - git-worktree baseline cache (SHA-keyed), statistical perf gate (Mann–Whitney U), hard-guarded forward-only data-migration
-  - `scripts/score-regression.sh` (rubric + verdict) + `tests/test-regression.sh` (43 assertions, 9 golden fixtures)
+  - `scripts/score-regression.sh` (rubric + verdict) + `tests/test-regression.sh` (50 assertions, 10 golden fixtures)
   - Subcommand count: 13 → 14
-- Guide updates reflecting v2.2.0 command file structure
+- Guide updates reflecting v2.1.4 command file structure
 - Scenario guide coverage for evals, improve, and chain workflows
 - Community contributions and bug reports
 

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -2,6 +2,28 @@
 
 All notable changes to the autoresearch project are documented here.
 
+## v2.2.0 — Regression Stability Gate (2026-06-19)
+
+**Theme:** A 14th family member — a heavy, layered regression-testing gate that proves a change is safe to push.
+
+### Added
+- `/autoresearch:regression` — stability gate that captures baseline behavior from a `git worktree` of the base ref, diffs the candidate across 8 dimensions, and emits a single STABLE / UNSTABLE verdict
+  - **Classification phase** enforces the core invariant: a regression is a green→red transition only. red→red (pre-existing), absent→red (new coverage), and flake→red (flaky) are classified out, never counted. Tests matched by test-id then path.
+  - **Tiered verdict:** HARD gate (`functional`, `api-contract`, `data-migration`, `integration-e2e`) — any green→red = UNSTABLE; SCORE 0–100 noise-tolerant weighted (`flakiness` .30, `performance` .30, `resource` .20, `visual-ui` .20), UNSTABLE below threshold 95
+  - **4 input axes:** diff (default), repeat N×, full, matrix (opt-in)
+  - **Baseline cache** keyed by full SHA (`baseline/<full-sha>/`), per-dim setup tiers; `--baseline-cache` on by default
+  - **Statistical perf gate:** 7 independent-process samples/side, Mann–Whitney U, flagged only beyond `max(noise-band%, k·stdev)`; visual via pixel-ratio / SSIM ignoring anti-aliasing
+  - **data-migration hard-guarded:** opt-in, forward-only by default, refuses any DB URL not matching the ephemeral/allowlisted set (`*test*`, `*ci*`, container)
+  - **Hunter reproducibility gate:** bisect only for HARD dims passing 3/3 reproduction; SCORE / non-deterministic → differential root-cause
+  - **`--fix` re-gate:** max 3 cycles, each must strictly shrink the blocking-set or STOP "not converging"; no HARD-gate bypass
+  - Composable: `--predict`, `--reason`, `--probe`, `--debug`, `--fix/--fix-cycles`, `--evals`, `--chain`, `--max-runs`. Canonical combo `--predict --evals --fix --ship`
+- `scripts/score-regression.sh` — scoring backend: `rubric` (spec quality gate) + `verdict` (TSV → STABLE/UNSTABLE, CI exit codes)
+- `tests/test-regression.sh` + 9 golden TSV fixtures under `tests/fixtures/regression/`
+
+### Changed
+- Command count 13 → 14 across `marketplace.json`, `plugin.json`, all 5 `SKILL.md` routing tables, README, and COMPARISON
+- Version 2.1.3 → 2.2.0
+
 ## v2.1.3 — Wiki Knowledge Base + Distribution Parity (2026-06-16)
 
 **Theme:** A navigable knowledge base from `learn`, plus a clean, fully-synced distribution across all platforms.

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -2,7 +2,7 @@
 
 All notable changes to the autoresearch project are documented here.
 
-## v2.2.0 — Regression Stability Gate (2026-06-19)
+## v2.1.4 — Regression Stability Gate (2026-06-19)
 
 **Theme:** A 14th family member — a heavy, layered regression-testing gate that proves a change is safe to push.
 
@@ -18,11 +18,11 @@ All notable changes to the autoresearch project are documented here.
   - **`--fix` re-gate:** max 3 cycles, each must strictly shrink the blocking-set or STOP "not converging"; no HARD-gate bypass
   - Composable: `--predict`, `--reason`, `--probe`, `--debug`, `--fix/--fix-cycles`, `--evals`, `--chain`, `--max-runs`. Canonical combo `--predict --evals --fix --ship`
 - `scripts/score-regression.sh` — scoring backend: `rubric` (spec quality gate) + `verdict` (TSV → STABLE/UNSTABLE, CI exit codes)
-- `tests/test-regression.sh` + 9 golden TSV fixtures under `tests/fixtures/regression/`
+- `tests/test-regression.sh` + 10 golden TSV fixtures under `tests/fixtures/regression/`
 
 ### Changed
 - Command count 13 → 14 across `marketplace.json`, `plugin.json`, all 5 `SKILL.md` routing tables, README, and COMPARISON
-- Version 2.1.3 → 2.2.0
+- Version 2.1.3 → 2.1.4
 
 ## v2.1.3 — Wiki Knowledge Base + Distribution Parity (2026-06-16)
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -26,7 +26,7 @@ Autoresearch automates this entire loop with mechanical verification, automatic 
 
 ## Key Features
 
-- **13 subcommands** covering the full development lifecycle (see table below)
+- **14 subcommands** covering the full development lifecycle (see table below)
 - **Bounded by default** — every looping command has a sane default iteration count; opt into unbounded with `Iterations: unlimited`
 - **Guard system** — optional safety net that reverts commits when quality regresses
 - **Git as memory** — every experiment committed; agent reads history to avoid repeating failures

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Autoresearch v2.2.0 is a modular, markdown-driven autonomous iteration framework. The core architectural shift from v2.0.x is the **thin SKILL.md + self-contained command files** pattern: the skill file is a routing table; all protocol is embedded in 14 self-contained command files. Only the invoked command file loads per invocation, reducing token cost by ~95%.
+Autoresearch v2.1.4 is a modular, markdown-driven autonomous iteration framework. The core architectural shift from v2.0.x is the **thin SKILL.md + self-contained command files** pattern: the skill file is a routing table; all protocol is embedded in 14 self-contained command files. Only the invoked command file loads per invocation, reducing token cost by ~95%.
 
 Multi-platform: Claude Code, OpenCode, and Codex are all supported via a single `scripts/transform.sh` that produces platform-specific distributions from the canonical `.claude/` source.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Autoresearch v2.1.3 is a modular, markdown-driven autonomous iteration framework. The core architectural shift from v2.0.x is the **thin SKILL.md + self-contained command files** pattern: the skill file is a routing table; all protocol is embedded in 13 self-contained command files. Only the invoked command file loads per invocation, reducing token cost by ~95%.
+Autoresearch v2.2.0 is a modular, markdown-driven autonomous iteration framework. The core architectural shift from v2.0.x is the **thin SKILL.md + self-contained command files** pattern: the skill file is a routing table; all protocol is embedded in 14 self-contained command files. Only the invoked command file loads per invocation, reducing token cost by ~95%.
 
 Multi-platform: Claude Code, OpenCode, and Codex are all supported via a single `scripts/transform.sh` that produces platform-specific distributions from the canonical `.claude/` source.
 
@@ -27,7 +27,7 @@ graph TB
     subgraph "Canonical Source"
         SKILL[.claude/skills/autoresearch/SKILL.md\nthin routing table — 41 lines]
         CMD[.claude/commands/autoresearch.md]
-        CMDS[.claude/commands/autoresearch/*.md\n13 self-contained command files]
+        CMDS[.claude/commands/autoresearch/*.md\n14 self-contained command files]
         REF[.claude/skills/autoresearch/references/\n3 focused reference files]
     end
 

--- a/guide/README.md
+++ b/guide/README.md
@@ -4,7 +4,7 @@
 
 **By [Udit Goenka](https://udit.co)**
 
-[![Version](https://img.shields.io/badge/version-2.2.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-2.1.4-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>

--- a/guide/README.md
+++ b/guide/README.md
@@ -4,7 +4,7 @@
 
 **By [Udit Goenka](https://udit.co)**
 
-[![Version](https://img.shields.io/badge/version-2.1.3-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
+[![Version](https://img.shields.io/badge/version-2.2.0-blue.svg)](https://github.com/uditgoenka/autoresearch/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>
@@ -42,7 +42,7 @@ npx skills add uditgoenka/autoresearch
 | [/autoresearch:probe](autoresearch-probe.md) | 8 personas interrogate requirements to saturation |
 | [/autoresearch:improve](autoresearch-improve.md) | Research ICP challenges, discover improvements, generate PRDs |
 | [/autoresearch:evals](autoresearch-evals.md) | Analyze results TSV — trends, plateaus, checkpoints |
-| [Chains & Combinations](chains-and-combinations.md) | Multi-command pipelines with all 13 commands |
+| [Chains & Combinations](chains-and-combinations.md) | Multi-command pipelines with all 14 commands |
 | [Examples by Domain](examples-by-domain.md) | Real-world examples: software, sales, marketing, DevOps, ML, HR |
 | [Advanced Patterns](advanced-patterns.md) | Guards, MCP, CI/CD, evals checkpoints, transform.sh |
 | [Hooks Reference](hooks.md) | 9 auto-firing hooks: safety gates, context injection, notifications |

--- a/guide/autoresearch-codex.md
+++ b/guide/autoresearch-codex.md
@@ -1,6 +1,6 @@
 # Autoresearch for Codex — v2.1.0
 
-Codex distribution of autoresearch. Same 13 commands, same flags, same output contracts as the Claude Code version. Entry point: `$autoresearch <command>`.
+Codex distribution of autoresearch. Same 14 commands, same flags, same output contracts as the Claude Code version. Entry point: `$autoresearch <command>`.
 
 ---
 
@@ -31,7 +31,7 @@ Codex uses `$autoresearch` prefix:
 | `/autoresearch:evals` | `$autoresearch evals` |
 | `/autoresearch:ship` | `$autoresearch ship` |
 
-All 13 commands follow the same pattern: `$autoresearch <command> [flags]`.
+All 14 commands follow the same pattern: `$autoresearch <command> [flags]`.
 
 ---
 

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -20,7 +20,7 @@ Works on anything with a measurable outcome — code coverage, bundle size, API 
 npx skills add uditgoenka/autoresearch
 ```
 
-All 13 commands are immediately available. No restart needed.
+All 14 commands are immediately available. No restart needed.
 
 ### Manual — Project-Level
 

--- a/plugins/autoresearch/.codex-plugin/plugin.json
+++ b/plugins/autoresearch/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "autoresearch",
-  "version": "2.1.3-codex.0",
-  "description": "Autonomous improvement engine for Codex. 13 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve.",
+  "version": "2.2.0-codex.0",
+  "description": "Autonomous improvement engine for Codex. 14 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve, regression.",
   "author": {
     "name": "Udit Goenka",
     "url": "https://github.com/uditgoenka"
@@ -22,7 +22,7 @@
   "interface": {
     "displayName": "Autoresearch",
     "shortDescription": "Autonomous improvement workflows for Codex.",
-    "longDescription": "13 self-contained commands: core iterate loop, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve. Thin routing SKILL.md + per-command instruction files.",
+    "longDescription": "14 self-contained commands: core iterate loop, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve, regression. Thin routing SKILL.md + per-command instruction files.",
     "developerName": "Udit Goenka",
     "category": "Productivity",
     "capabilities": [

--- a/plugins/autoresearch/.codex-plugin/plugin.json
+++ b/plugins/autoresearch/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoresearch",
-  "version": "2.2.0-codex.0",
+  "version": "2.1.4-codex.0",
   "description": "Autonomous improvement engine for Codex. 14 commands: iterate, plan, debug, fix, security, ship, scenario, predict, learn, reason, probe, evals, improve, regression.",
   "author": {
     "name": "Udit Goenka",

--- a/plugins/autoresearch/skills/autoresearch/SKILL.md
+++ b/plugins/autoresearch/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.2.0
+version: 2.1.4
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration

--- a/plugins/autoresearch/skills/autoresearch/SKILL.md
+++ b/plugins/autoresearch/skills/autoresearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoresearch
 description: "Autonomous iteration loop: modify, verify, keep/discard against any metric"
-version: 2.1.3
+version: 2.2.0
 ---
 
 # Autoresearch — Autonomous Goal-directed Iteration
@@ -29,6 +29,7 @@ version: 2.1.3
 | `$autoresearch probe` | 8 personas interrogate requirements until saturation | 15 |
 | `$autoresearch improve` | Research ICP challenges, discover improvements, generate PRDs | 15 |
 | `$autoresearch evals` | Analyze iteration results: trends, plateaus, regressions | N/A |
+| `$autoresearch regression` | Regression stability gate: baseline vs candidate, verdict STABLE/UNSTABLE | N/A |
 
 ## Universal Flags
 

--- a/plugins/autoresearch/skills/autoresearch/regression.md
+++ b/plugins/autoresearch/skills/autoresearch/regression.md
@@ -1,0 +1,110 @@
+---
+name: autoresearch:regression
+description: "Layered regression stability gate: capture baseline behavior on the base ref, diff the candidate, verdict STABLE/UNSTABLE before you push"
+argument-hint: "[Base: <ref>] [Scope: <glob>] [--select auto|full|affected] [--samples N] [--noise-band %] [--matrix] [--max-runs N] [--baseline-cache] [Baseline: <prebuilt-ref>] [--probe|--no-probe|--probe deep] [--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain]"
+---
+
+EXECUTE IMMEDIATELY.
+
+A regression is a **green→red transition ONLY**. The gate orchestrates the project's OWN test/bench/snapshot/migrate commands (it is a protocol, not a bundled framework), captures baseline behavior in an isolated git worktree, re-runs the candidate, and reports a tiered ship/no-ship verdict.
+
+## Parse Arguments
+
+Extract from $ARGUMENTS:
+- `Base:` or `--base` — base ref to diff against. Default: `git merge-base HEAD main` (else `main`/`master`).
+- `Scope:` or `--scope` — file globs limiting the change surface.
+- `--select auto|full|affected` — test selection (default `auto`). `auto` = use the detected affected-test mapper if available, else FULL suite. Never a silent subset.
+- `--samples N` — SCORE samples/side (default 7). `--noise-band %` — perf tolerance (default 5%).
+- `--matrix` — opt-in matrix axis (OFF by default). `--max-runs N` — ceiling (default 200).
+- `--baseline-cache` (default on) — reuse `baseline/<full-sha>/` by SHA. `Baseline: <prebuilt-ref>` — bypass capture.
+- `--probe` (default) / `--probe deep` / `--no-probe`.
+- `--predict --reason --debug --fix --fix-cycles N --evals --evals-interval N --chain <targets>` and `--<sub>` shorthand.
+- `Iterations:` — repeat-axis count for `--select`/repeat sweeps.
+
+## Setup / Probe-on-launch
+
+1. Auto-detect per-dimension verify commands: `package.json` scripts, `Makefile`, `nx`, migrate config, bench/snapshot/size scripts.
+2. AskUserQuestion (single batch) to confirm detected commands + base ref + which dimensions to run.
+3. **Auto-skip probe** when CI / no-TTY / `--mode autonomous` / complete-config / chained-handoff — log the inferred config instead of asking.
+
+## Classification Phase (first-class, before any differential)
+
+Establish the baseline green-set per dimension, then tag each unit. Match by **test-id first, then path**.
+
+| State | Meaning | Gated? |
+|---|---|---|
+| `regression-eligible` | green on baseline | YES — only green→red counts |
+| `pre-existing` | red→red (already failing) | no — excluded |
+| `new-coverage` | absent→red (brand-new test) | no — new coverage, ungated |
+| `flaky` | nondeterministic on baseline | no — routed to flakiness SCORE |
+| `baseline-unavailable` | dimension never green | no — advisory only |
+
+**Core invariant: red→red, absent→red, and flake→red are NOT regressions.** Run flakiness N× on **both** baseline and candidate; a candidate failure inside the baseline flake-envelope routes to flakiness SCORE, never to a regression. `5/5 green ≠ non-flaky` — detection probability is `1−(1−p)^n` (≈23% at p=5%, n=5); print it.
+
+## Baseline Capture
+
+`git worktree add --detach <full-sha>` (detached SHA — avoids "branch already checked out" when Base==HEAD) → `baseline/<full-sha>/`; `--baseline-cache` reuses by SHA. Then per worktree: `git submodule update --init` + dependency install (lockfile is SHA-pinned so the cache stays sound). Per-dimension **setup tiers**: api-contract = file-diff, no build; functional / integration-e2e / data-migration = full env. On completion or crash: `git worktree remove` + `git worktree prune`. Warn on concurrent index-lock contention. `Baseline: <prebuilt-ref>` bypasses capture.
+
+## Dimension Registry (8)
+
+| Dim | Tier | Compare | Key params |
+|---|---|---|---|
+| functional | HARD | baseline green-set vs candidate; new fail = regression | test cmd, globs |
+| api-contract | HARD | schema/exports diff → breaking? | schema cmd, breaking ruleset |
+| data-migration | HARD | default: up applies clean + idempotent re-apply + app boots/schema valid; schema/rowcount roundtrip opt-in | migrate cmds, fixture, allowlisted DB |
+| integration-e2e | HARD | e2e green-set diff | e2e cmd |
+| flakiness | SCORE | run N× on baseline + candidate, count nondeterministic | runs (def 5), flake-threshold |
+| performance | SCORE | K **independent-process** samples/side, Mann-Whitney U AND effect beyond `max(noise-band%, k·stdev)`, report median delta | bench cmd, samples=7, noise-band=5%, k=2 |
+| resource | SCORE | mem/bundle/size delta vs budget | size cmd, budget |
+| visual-ui | SCORE | containerize render; default `maxDiffPixelRatio` + AA-detection; SSIM = per-page escalation | snapshot cmd, diff-threshold, mask regions |
+
+`--select auto` mapper (`jest --findRelatedTests` fed the changed-file list; `nx affected` project-graph) is **best-effort static-import** — blind to dynamic/runtime/global-setup couplings. The report names the mapper + its blind-spot caveat; a HARD STABLE earned on an affected subset prints "run `--select full` for high-stakes". FULL suite is the correctness default.
+
+- **performance independence:** each sample = an independent process launch (warmups discarded), never an in-process iteration — autocorrelation/GC/thermal otherwise violate Mann-Whitney's independence assumption. At n=7 the test detects only ≳1σ regressions; raise `--samples` for tight gates.
+- **data-migration guard:** opt-in. Before any migration the DB URL MUST pass an **anchored** allowlist — host is exactly `localhost` / `127.0.0.1` / a container or service hostname, OR the database name carries a `_test` / `_ci` suffix. A bare substring (e.g. `test` inside `latest`, `ci` inside `precision`) does **not** qualify. Anything else is refused — ephemeral only, never dev/prod — and even an allowlisted URL requires explicit user confirm before applying. Missing/absent down-migration = forward-only advisory, **never a finding**.
+
+## Differential Loop (per dim × axis × run)
+
+Run candidate verify vs baseline metric → compute `regressed` bool + 0-100 `subscore`. Axes: `diff` (default), `repeat N×`, `full`, `matrix` (opt-in). Log one TSV row per cell.
+
+**--max-runs ceiling:** projected = dims × axes × samples × matrix-cells; if > `--max-runs` (default 200) → warn + require confirm (CI default = abort with message).
+
+## Verdict
+
+- Any HARD `regressed=true` with `classification=eligible` → **UNSTABLE** (green→red hard-blocks).
+- Else `stability_score = Σ(weight × dim_subscore)` over SCORE dims that ran (flakiness .30 / performance .30 / resource .20 / visual .20, renormalized over present dims). **STABLE iff ≥ 95** (`REG_THRESHOLD`/weights overridable).
+- Print the **score math** (per-dim contribution table) + declare **dims-ran vs UNAVAILABLE** — an UNAVAILABLE dimension is always listed, never silently passed.
+
+Backed by `scripts/score-regression.sh verdict <results.tsv>` (exit 0 STABLE / 1 UNSTABLE).
+
+## Hunter (root cause)
+
+On a confirmed HARD regression, auto-engage. Bisect (reuse `debug`) ONLY when the failing case passes a **3/3 reproducibility gate**. SCORE / non-deterministic regressions → differential root-cause + optional `--reason` / `--predict`, no bisect. Non-reproducible → "manual triage" finding.
+
+## --fix Re-gate
+
+`--fix` repairs blocking regressions, max **3 cycles** (`--fix-cycles N`). Each cycle MUST strictly shrink the blocking-set else STOP "fix not converging". Intermediate re-gate scopes to failing+touched dims; the final cycle runs the full battery. No HARD-gate bypass.
+
+## Output
+
+`autoresearch/regression-{YYMMDD}-{HHMM}/` → `regression-results.tsv`, `stability-report.md`, `dimensions/<dim>.md`, `baseline/`, `evals-summary.md` (if `--evals`), `handoff.json`.
+
+TSV header: `# metric_direction: higher_is_better` then
+`iteration\ttimestamp\tdimension\taxis\ttier\tclassification\tbaseline\tcandidate\tdelta\tregressed\tsubscore\tseverity\tstatus\tfile_line\tdescription`.
+
+## Eval Checkpoint (--evals flag)
+
+Interval = floor(max_runs / 3), min 1 (fixed 10 if unbounded); override `--evals-interval N`. Every interval, analyze the results TSV; print trend (up/flat/down) + one-line recommendation. Plateau 3+ checkpoints → recommend early stop. At end → full summary to `evals-summary.md`.
+
+## Chain Handoff
+
+Write `handoff.json` to the output directory: version "2.1.0", source "regression", timestamp,
+`status` ∈ family enum {COMPLETE, CONVERGED, SATURATED, BOUNDED, USER_INTERRUPT, ERROR} (backward-compat with evals/ship consumers),
+`verdict` ∈ {STABLE, UNSTABLE, BASELINE_UNAVAILABLE} + `regression_state` ∈ {REGRESSION_FOUND, REGRESSION_FIXED, none} — `ship` reads `verdict` for the deploy-gate,
+`results_tsv` path, `findings` = blocking regressions (dim, severity, file_line, classification), `config`{base, scope, dims, axes, verdict-math}.
+
+If `--fix` → chain to fix automatically. Invoke next `--chain` target in order; propagate `--evals`. Canonical combo: `--predict --evals --fix --ship` = predict → gate → (hunter on HARD) → fix(≤3) → re-gate → ship iff STABLE (deploy still needs explicit approval).
+
+## Safety
+
+Verify-command screen (no `rm -rf` / `curl|sh`); worktree cleanup + prune on crash; data-migration refuses any non-allowlisted DB URL; probe auto-skips non-interactively; chained `ship` never auto-deploys.

--- a/scripts/score-regression.sh
+++ b/scripts/score-regression.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# score-regression.sh — scoring backend for autoresearch:regression
+#
+#   rubric  [file]          → grep-rubric quality score of regression.md   → "SCORE: N"
+#   verdict <results.tsv>   → tiered stability verdict from a results TSV
+#
+# verdict logic:
+#   - any HARD row that is a green→red regression (classification=eligible, regressed=true) → UNSTABLE
+#   - else weighted SCORE: per-dim worst subscore, weights renormalized over dims that ran,
+#     STABLE iff stability_score >= threshold (default 95)
+#   - classification in {pre-existing,new-coverage,baseline-unavailable,flaky} never gates
+#   - exit 0 STABLE / 1 UNSTABLE / 2 ERROR   (CI-usable)   · score math → stderr
+#
+# Overridable env: REG_THRESHOLD, REG_W_FLAKINESS, REG_W_PERFORMANCE, REG_W_RESOURCE, REG_W_VISUAL
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SPEC_DEFAULT="$REPO_ROOT/claude-plugin/commands/autoresearch/regression.md"
+
+REG_THRESHOLD="${REG_THRESHOLD:-95}"
+REG_W_FLAKINESS="${REG_W_FLAKINESS:-0.30}"
+REG_W_PERFORMANCE="${REG_W_PERFORMANCE:-0.30}"
+REG_W_RESOURCE="${REG_W_RESOURCE:-0.20}"
+REG_W_VISUAL="${REG_W_VISUAL:-0.20}"
+
+# ---------------------------------------------------------------------------
+# rubric: grep the protocol spec for required invariants/sections/flags.
+# Each pattern matched = +1. Prints "SCORE: N" only.
+# ---------------------------------------------------------------------------
+rubric() {
+  local file="${1:-$SPEC_DEFAULT}"
+  if [[ ! -f "$file" ]]; then echo "SCORE: 0"; return 0; fi
+
+  local checks=(
+    "classification"
+    "green.{0,3}red"
+    "regression.eligible|[^a-z]eligible"
+    "pre-existing"
+    "new-coverage"
+    "baseline.unavailable|BASELINE_UNAVAILABLE"
+    "functional"
+    "api-contract"
+    "data-migration"
+    "integration-e2e"
+    "flakiness"
+    "performance"
+    "resource"
+    "visual"
+    "HARD"
+    "SCORE"
+    "worktree"
+    "--detach|detach"
+    "submodule"
+    "baseline.cache|--baseline-cache"
+    "--select"
+    "findRelatedTests|nx affected|affected"
+    "Mann.?Whitney"
+    "independent.process"
+    "effect.size|median delta"
+    "SSIM|maxDiffPixelRatio|pixel.ratio"
+    "samples"
+    "noise-band"
+    "forward-only"
+    "allowlist"
+    "fix-cycle|--fix-cycles"
+    "probe"
+    "auto-skip"
+    "--max-runs"
+    "handoff"
+    "verdict"
+    "STABLE"
+    "UNSTABLE"
+  )
+
+  local score=0 pat
+  for pat in "${checks[@]}"; do
+    if grep -qiE -- "$pat" "$file"; then score=$((score + 1)); fi
+  done
+  echo "SCORE: $score"
+}
+
+# ---------------------------------------------------------------------------
+# verdict: reduce a results TSV to STABLE|UNSTABLE + stability score.
+# ---------------------------------------------------------------------------
+verdict() {
+  local tsv="${1:?usage: verdict <results.tsv>}"
+  if [[ ! -f "$tsv" ]]; then
+    echo "VERDICT: ERROR"; echo "score=0.0"; echo "blocking=missing-tsv"
+    return 2
+  fi
+
+  awk -v FS='\t' \
+      -v wF="$REG_W_FLAKINESS" -v wP="$REG_W_PERFORMANCE" \
+      -v wR="$REG_W_RESOURCE"  -v wV="$REG_W_VISUAL" \
+      -v thr="$REG_THRESHOLD" '
+    /^#/      { next }              # comment (e.g. metric_direction)
+    $1=="iteration" { next }        # header
+    NF < 11   { next }              # malformed / short row
+    {
+      nrows++;
+      dim=$3; tier=$5; cls=$6; regressed=$10; subv=$11+0;
+      present[dim]=1;
+      if (tier=="HARD" && regressed=="true" && cls=="eligible") hardset[dim]=1;
+      if (tier=="SCORE" && cls!="baseline-unavailable") {
+        if (!(dim in dmin) || subv < dmin[dim]) dmin[dim]=subv;   # per-dim worst case
+      }
+    }
+    END {
+      # No measurable data rows ran at all → nothing to gate on. Must NOT read as a
+      # green ship signal: an empty/header-only TSV or all-dims-unavailable run is
+      # advisory, not STABLE. Emit BASELINE_UNAVAILABLE + non-zero exit.
+      if (nrows==0) {
+        printf "VERDICT: BASELINE_UNAVAILABLE\n";
+        printf "score=0.00\n";
+        printf "blocking=no-dims-ran\n";
+        printf "dims_ran=none\n";
+        printf "dims_unavailable=functional,api-contract,data-migration,integration-e2e,flakiness,performance,resource,visual-ui\n";
+        exit 2;
+      }
+
+      hb="";
+      for (d in hardset) hb = hb (hb==""?"":",") d;
+
+      wt["flakiness"]=wF; wt["performance"]=wP; wt["resource"]=wR; wt["visual-ui"]=wV;
+      num=0; den=0;
+      for (d in dmin) { w=(d in wt)?wt[d]:0; if (w>0){ num+=w*dmin[d]; den+=w; } }
+      score = (den>0) ? num/den : 100;
+
+      split("functional,api-contract,data-migration,integration-e2e,flakiness,performance,resource,visual-ui", reg, ",");
+      ran=""; unavail="";
+      for (i=1;i<=8;i++){
+        if (reg[i] in present) ran = ran (ran==""?"":",") reg[i];
+        else                   unavail = unavail (unavail==""?"":",") reg[i];
+      }
+
+      unstable = (hb!="") || (score < thr);
+      verdict  = unstable ? "UNSTABLE" : "STABLE";
+      if      (hb!="" && score<thr) blocking = hb ",score";
+      else if (hb!="")              blocking = hb;
+      else if (score<thr)           blocking = "score";
+      else                          blocking = "none";
+
+      # Display floors to 2 decimals (never rounds up): a true 94.9999 must print as
+      # 94.99 — not 95.00 — so the shown number cannot read >= threshold while UNSTABLE.
+      # The gate itself (above) compares full precision.
+      disp = int(score*100)/100;
+
+      printf "VERDICT: %s\n", verdict;
+      printf "score=%.2f\n", disp;
+      printf "blocking=%s\n", blocking;
+      printf "dims_ran=%s\n", (ran==""?"none":ran);
+      printf "dims_unavailable=%s\n", (unavail==""?"none":unavail);
+
+      for (d in dmin) printf "  %-12s subscore=%.2f weight=%s\n", d, int(dmin[d]*100)/100, ((d in wt)?wt[d]:"0") > "/dev/stderr";
+      printf "  stability_score=%.2f threshold=%s\n", disp, thr > "/dev/stderr";
+
+      exit (unstable ? 1 : 0);
+    }
+  ' "$tsv"
+}
+
+case "${1:-}" in
+  rubric)  shift; rubric  "$@" ;;
+  verdict) shift; verdict "$@" ;;
+  *) echo "usage: $0 {rubric [file] | verdict <results.tsv>}" >&2; exit 64 ;;
+esac

--- a/tests/fixtures/regression/absent-to-red.tsv
+++ b/tests/fixtures/regression/absent-to-red.tsv
@@ -1,0 +1,7 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	functional	diff	HARD	new-coverage	absent	fail	-1	true	0	low	red	test/new.spec.ts:3	brand-new test, no baseline
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	0	0	0	false	100	none	green	-	deterministic
+3	2026-06-19T11:45:02Z	performance	repeat	SCORE	eligible	100	100	0	false	100	none	green	-	in band
+4	2026-06-19T11:45:03Z	resource	full	SCORE	eligible	100	100	0	false	100	none	green	-	within budget
+5	2026-06-19T11:45:04Z	visual-ui	full	SCORE	eligible	100	100	0	false	100	none	green	-	pixel-ratio ok

--- a/tests/fixtures/regression/empty.tsv
+++ b/tests/fixtures/regression/empty.tsv
@@ -1,0 +1,2 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description

--- a/tests/fixtures/regression/flake-to-red.tsv
+++ b/tests/fixtures/regression/flake-to-red.tsv
@@ -1,0 +1,7 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	functional	diff	HARD	flaky	flake	fail	0	true	0	medium	red	test/race.spec.ts:7	nondeterministic on baseline
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	100	100	0	false	100	none	green	test/race.spec.ts:7	flake tolerated, not a green->red regression
+3	2026-06-19T11:45:02Z	performance	repeat	SCORE	eligible	100	100	0	false	100	none	green	-	in band
+4	2026-06-19T11:45:03Z	resource	full	SCORE	eligible	100	100	0	false	100	none	green	-	within budget
+5	2026-06-19T11:45:04Z	visual-ui	full	SCORE	eligible	100	100	0	false	100	none	green	-	pixel-ratio ok

--- a/tests/fixtures/regression/green-to-red.tsv
+++ b/tests/fixtures/regression/green-to-red.tsv
@@ -1,0 +1,4 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	functional	diff	HARD	eligible	pass	fail	-1	true	0	high	red	src/auth.ts:42	login returns 500 after change
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	0	0	0	false	100	none	green	-	deterministic

--- a/tests/fixtures/regression/perf-in-band.tsv
+++ b/tests/fixtures/regression/perf-in-band.tsv
@@ -1,0 +1,6 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	performance	repeat	SCORE	eligible	120.4	121.1	0.7	false	100	none	green	bench/api.bench.ts	within noise band
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	0	0	0	false	100	none	green	-	deterministic
+3	2026-06-19T11:45:02Z	resource	full	SCORE	eligible	100	100	0	false	100	none	green	-	within budget
+4	2026-06-19T11:45:03Z	visual-ui	full	SCORE	eligible	100	100	0	false	100	none	green	-	pixel-ratio ok

--- a/tests/fixtures/regression/perf-over-band.tsv
+++ b/tests/fixtures/regression/perf-over-band.tsv
@@ -1,0 +1,6 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	performance	repeat	SCORE	eligible	120.0	168.0	48.0	true	60	high	red	bench/api.bench.ts	+40% beyond noise band, Mann-Whitney significant
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	0	0	0	false	100	none	green	-	deterministic
+3	2026-06-19T11:45:02Z	resource	full	SCORE	eligible	100	100	0	false	100	none	green	-	within budget
+4	2026-06-19T11:45:03Z	visual-ui	full	SCORE	eligible	100	100	0	false	100	none	green	-	pixel-ratio ok

--- a/tests/fixtures/regression/red-to-red.tsv
+++ b/tests/fixtures/regression/red-to-red.tsv
@@ -1,0 +1,7 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	functional	diff	HARD	pre-existing	fail	fail	0	true	0	high	red	src/legacy.ts:9	already failing before change
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	0	0	0	false	100	none	green	-	deterministic
+3	2026-06-19T11:45:02Z	performance	repeat	SCORE	eligible	100	100	0	false	100	none	green	-	in band
+4	2026-06-19T11:45:03Z	resource	full	SCORE	eligible	100	100	0	false	100	none	green	-	within budget
+5	2026-06-19T11:45:04Z	visual-ui	full	SCORE	eligible	100	100	0	false	100	none	green	-	pixel-ratio ok

--- a/tests/fixtures/regression/score-boundary-94.tsv
+++ b/tests/fixtures/regression/score-boundary-94.tsv
@@ -1,0 +1,7 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	functional	diff	HARD	eligible	pass	pass	0	false	100	none	green	-	no behavioral change
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	94	94	0	false	94	low	amber	-	just below threshold
+3	2026-06-19T11:45:02Z	performance	repeat	SCORE	eligible	94	94	0	false	94	low	amber	-	just below threshold
+4	2026-06-19T11:45:03Z	resource	full	SCORE	eligible	94	94	0	false	94	low	amber	-	just below threshold
+5	2026-06-19T11:45:04Z	visual-ui	full	SCORE	eligible	94	94	0	false	94	low	amber	-	just below threshold

--- a/tests/fixtures/regression/score-boundary-95.tsv
+++ b/tests/fixtures/regression/score-boundary-95.tsv
@@ -1,0 +1,7 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	functional	diff	HARD	eligible	pass	pass	0	false	100	none	green	-	no behavioral change
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	95	95	0	false	95	low	amber	-	at threshold
+3	2026-06-19T11:45:02Z	performance	repeat	SCORE	eligible	95	95	0	false	95	low	amber	-	at threshold
+4	2026-06-19T11:45:03Z	resource	full	SCORE	eligible	95	95	0	false	95	low	amber	-	at threshold
+5	2026-06-19T11:45:04Z	visual-ui	full	SCORE	eligible	95	95	0	false	95	low	amber	-	at threshold

--- a/tests/fixtures/regression/unavailable-dim.tsv
+++ b/tests/fixtures/regression/unavailable-dim.tsv
@@ -1,0 +1,5 @@
+# metric_direction: higher_is_better
+iteration	timestamp	dimension	axis	tier	classification	baseline	candidate	delta	regressed	subscore	severity	status	file_line	description
+1	2026-06-19T11:45:00Z	functional	diff	HARD	eligible	pass	pass	0	false	100	none	green	-	no behavioral change
+2	2026-06-19T11:45:01Z	flakiness	repeat	SCORE	eligible	100	100	0	false	100	none	green	-	deterministic
+3	2026-06-19T11:45:02Z	performance	repeat	SCORE	eligible	100	100	0	false	100	none	green	-	in band

--- a/tests/test-regression.sh
+++ b/tests/test-regression.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Test harness for autoresearch:regression — score-regression.sh (verdict + rubric),
+# the regression.md spec, mirror parity, and manifest count.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SCORE_SH="$REPO_ROOT/scripts/score-regression.sh"
+FIX="$REPO_ROOT/tests/fixtures/regression"
+SPEC="$REPO_ROOT/claude-plugin/commands/autoresearch/regression.md"
+RUBRIC_TARGET="${REG_RUBRIC_TARGET:-32}"
+
+PASS=0; FAIL=0; TOTAL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); }
+
+assert_eq()       { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 (expected '$1', got '$2')"; }
+assert_ge()       { [[ "$1" -ge "$2" ]] && pass "$3" || fail "$3 ($1 < $2)"; }
+assert_contains() { echo "$1" | grep -q "$2" && pass "$3" || fail "$3 (missing '$2')"; }
+
+V_OUT=""; V_CODE=0; V_VERDICT=""; V_SCORE=""
+run_verdict() {
+  V_OUT=$(bash "$SCORE_SH" verdict "$FIX/$1" 2>/dev/null); V_CODE=$?
+  V_VERDICT=$(echo "$V_OUT" | sed -n 's/^VERDICT: //p')
+  V_SCORE=$(echo "$V_OUT" | sed -n 's/^score=//p')
+}
+
+# ============================================================================
+printf '\n--- verdict: classification invariants (green->red only) ---\n'
+# ============================================================================
+
+run_verdict green-to-red.tsv
+assert_eq "UNSTABLE" "$V_VERDICT" "green->red HARD regression => UNSTABLE"
+assert_eq 1 "$V_CODE" "green->red exit 1"
+assert_contains "$V_OUT" "blocking=functional" "green->red blocks on functional dim"
+
+run_verdict red-to-red.tsv
+assert_eq "STABLE" "$V_VERDICT" "red->red (pre-existing) excluded => STABLE"
+assert_eq 0 "$V_CODE" "red->red exit 0"
+
+run_verdict absent-to-red.tsv
+assert_eq "STABLE" "$V_VERDICT" "absent->red (new-coverage) ungated => STABLE"
+assert_eq 0 "$V_CODE" "absent->red exit 0"
+
+run_verdict flake-to-red.tsv
+assert_eq "STABLE" "$V_VERDICT" "flake->red (flaky) routed to SCORE => STABLE"
+assert_eq 0 "$V_CODE" "flake->red exit 0"
+
+# ============================================================================
+printf '\n--- verdict: SCORE tier (noise-tolerant, weighted) ---\n'
+# ============================================================================
+
+run_verdict perf-in-band.tsv
+assert_eq "STABLE" "$V_VERDICT" "perf within noise band => STABLE"
+
+run_verdict perf-over-band.tsv
+assert_eq "UNSTABLE" "$V_VERDICT" "perf over band drops score => UNSTABLE"
+assert_eq "88.00" "$V_SCORE" "perf-over-band weighted score = 88.00"
+assert_eq 1 "$V_CODE" "perf-over-band exit 1"
+
+run_verdict score-boundary-95.tsv
+assert_eq "STABLE" "$V_VERDICT" "score 95 (== threshold) => STABLE"
+assert_eq "95.00" "$V_SCORE" "boundary score = 95.00"
+
+run_verdict score-boundary-94.tsv
+assert_eq "UNSTABLE" "$V_VERDICT" "score 94 (< threshold) => UNSTABLE"
+assert_eq "94.00" "$V_SCORE" "boundary score = 94.00"
+
+# ============================================================================
+printf '\n--- verdict: dimension availability self-detection ---\n'
+# ============================================================================
+
+run_verdict unavailable-dim.tsv
+assert_eq "STABLE" "$V_VERDICT" "unavailable dims => STABLE on present dims"
+assert_contains "$V_OUT" "dims_unavailable=.*resource" "resource listed UNAVAILABLE"
+assert_contains "$V_OUT" "dims_unavailable=.*visual-ui" "visual-ui listed UNAVAILABLE"
+
+# ============================================================================
+printf '\n--- verdict: empty / no-dims-ran + ERROR paths (no false-green ship) ---\n'
+# ============================================================================
+
+run_verdict empty.tsv
+assert_eq "BASELINE_UNAVAILABLE" "$V_VERDICT" "empty/header-only TSV (no dims ran) => BASELINE_UNAVAILABLE, not STABLE"
+assert_eq 2 "$V_CODE" "empty TSV exit 2 (non-ship)"
+assert_contains "$V_OUT" "blocking=no-dims-ran" "empty TSV blocks on no-dims-ran"
+
+MISS_OUT=$(bash "$SCORE_SH" verdict "$FIX/does-not-exist.tsv" 2>/dev/null); MISS_CODE=$?
+assert_contains "$MISS_OUT" "VERDICT: ERROR" "missing TSV => VERDICT: ERROR"
+assert_eq 2 "$MISS_CODE" "missing TSV exit 2"
+
+# ============================================================================
+printf '\n--- verdict: determinism ---\n'
+# ============================================================================
+
+OUT1=$(bash "$SCORE_SH" verdict "$FIX/perf-over-band.tsv" 2>/dev/null)
+OUT2=$(bash "$SCORE_SH" verdict "$FIX/perf-over-band.tsv" 2>/dev/null)
+assert_eq "$OUT1" "$OUT2" "verdict deterministic across runs"
+
+# ============================================================================
+printf '\n--- rubric: spec quality gate ---\n'
+# ============================================================================
+
+RSCORE=$(bash "$SCORE_SH" rubric "$SPEC" | sed -n 's/^SCORE: //p')
+assert_ge "${RSCORE:-0}" "$RUBRIC_TARGET" "rubric score >= $RUBRIC_TARGET (got ${RSCORE:-0})"
+
+# ============================================================================
+printf '\n--- spec: required invariants/sections present ---\n'
+# ============================================================================
+
+spec_has() { grep -qiE -- "$1" "$SPEC" && pass "$2" || fail "$2 (spec missing /$1/)"; }
+spec_has "green.{0,3}red transition only|green.{0,3}red"          "spec: green->red invariant"
+spec_has "classification"                                         "spec: classification phase"
+spec_has "baseline-unavailable|BASELINE_UNAVAILABLE"              "spec: baseline-unavailable state"
+spec_has "git worktree add --detach"                              "spec: worktree --detach"
+spec_has "submodule update --init"                                "spec: submodule init"
+spec_has "forward-only"                                           "spec: migration forward-only default"
+spec_has "Mann.?Whitney"                                          "spec: perf Mann-Whitney"
+spec_has "independent.process"                                    "spec: perf independent-process samples"
+spec_has "maxDiffPixelRatio|pixel.ratio"                          "spec: visual pixel-ratio default"
+spec_has "--max-runs"                                             "spec: --max-runs ceiling"
+spec_has "fix-cycles|3 cycles"                                    "spec: fix-cycle bound"
+spec_has "verdict.*STABLE|STABLE.*UNSTABLE"                       "spec: verdict field"
+spec_has "COMPLETE.*CONVERGED.*SATURATED|family enum"             "spec: handoff family status enum"
+
+# ============================================================================
+printf '\n--- distribution: mirror parity (5 surfaces byte-identical) ---\n'
+# ============================================================================
+
+MIRRORS=(
+  "$REPO_ROOT/.claude/commands/autoresearch/regression.md"
+  "$REPO_ROOT/.agents/skills/autoresearch/regression.md"
+  "$REPO_ROOT/plugins/autoresearch/skills/autoresearch/regression.md"
+  "$REPO_ROOT/.opencode/commands/autoresearch_regression.md"
+)
+for m in "${MIRRORS[@]}"; do
+  if [[ -f "$m" ]] && diff -q "$SPEC" "$m" >/dev/null 2>&1; then
+    pass "mirror parity: ${m#$REPO_ROOT/}"
+  else
+    fail "mirror parity: ${m#$REPO_ROOT/} (missing or diverged)"
+  fi
+done
+
+# ============================================================================
+printf '\n--- distribution: manifest command count = 14 + regression listed ---\n'
+# ============================================================================
+
+for mf in "$REPO_ROOT/.claude-plugin/marketplace.json" "$REPO_ROOT/claude-plugin/.claude-plugin/plugin.json" "$REPO_ROOT/plugins/autoresearch/.codex-plugin/plugin.json"; do
+  name="${mf#$REPO_ROOT/}"
+  grep -q "14 commands" "$mf" && pass "manifest count 14: $name" || fail "manifest count 14: $name"
+  grep -q "regression" "$mf"  && pass "manifest lists regression: $name" || fail "manifest lists regression: $name"
+done
+
+# ============================================================================
+printf '\n=== Results: %d/%d passed ===' "$PASS" "$TOTAL"
+if [[ "$FAIL" -gt 0 ]]; then printf ' (%d FAILED)\n' "$FAIL"; exit 1; else printf ' (all passed)\n'; exit 0; fi


### PR DESCRIPTION
## Summary

Adds **`/autoresearch:regression`** — the 14th family member — a heavy, layered **regression stability gate**. It captures baseline behavior from a `git worktree` of the base ref, diffs the candidate across **8 dimensions**, and emits a single **STABLE / UNSTABLE** verdict before you push.

## Core invariant

A regression is a **green->red transition only**. red->red (pre-existing), absent->red (new coverage), and flake->red (flaky) are classified out and **never gate**.

## Tiered verdict

- **HARD gate** (any green->red = UNSTABLE): `functional`, `api-contract`, `data-migration`, `integration-e2e`
- **SCORE** (0-100, noise-tolerant, weighted; UNSTABLE below threshold 95): `flakiness` .30, `performance` .30, `resource` .20, `visual-ui` .20 — weights renormalized over the dims that actually ran
- **`dims_unavailable`** is always declared; an empty / no-dims run yields `BASELINE_UNAVAILABLE` (exit 2), **never a false-green STABLE**

## What's in this PR

- `scripts/score-regression.sh` — scoring backend: `rubric` (spec quality gate) + `verdict` (TSV to STABLE/UNSTABLE, CI exit codes 0/1/2)
- `claude-plugin/commands/autoresearch/regression.md` — canonical protocol spec, mirrored byte-identical to all 5 surfaces
- `tests/test-regression.sh` + 10 golden TSV fixtures — **50 assertions**
- Distribution: command count **13 to 14**, version **2.1.3 to 2.2.0** across 3 plugin manifests (incl. the Codex one), 5 `SKILL.md` routing tables, README, COMPARISON, and docs

## Safety guards

- **data-migration** hard-guarded: opt-in, forward-only by default, **anchored** DB-URL allowlist (host = `localhost`/`127.0.0.1`/container, or dbname `_test`/`_ci` suffix — not a bare substring), explicit confirm before applying
- `git worktree` cleanup (`remove` + `prune`); no destructive git operations (no force push, no hard reset, no untracked-file wipe)
- `--max-runs` ceiling (warn+confirm past 200 cells; CI default aborts)

## Verification

- `tests/test-regression.sh` -> **50/50 pass**
- `tests/test-hooks.sh` (existing) -> **105/105 pass**
- Two independent reviews (correctness + security): all High/Medium findings resolved in this branch — empty-TSV false-green (H1), stale Codex manifest (H2), untested ERROR/empty paths (M1), display/verdict rounding contradiction (M2), and the substring allowlist loophole (security) are all fixed.