### PR TITLE
docs: restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,11 +758,11 @@ Areas of interest: new domain examples, verification script templates, CI/CD int
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=uditgoenka%2Fautoresearch&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#uditgoenka/autoresearch&type=timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=uditgoenka/autoresearch&type=timeline&theme=dark&legend=bottom-right&v=20260319" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=uditgoenka/autoresearch&type=timeline&legend=bottom-right&v=20260319" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=uditgoenka/autoresearch&type=timeline&legend=bottom-right&v=20260319" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=uditgoenka/autoresearch&type=timeline&theme=dark&legend=bottom-right&v=20260319" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=uditgoenka/autoresearch&type=timeline&legend=bottom-right&v=20260319" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=uditgoenka/autoresearch&type=timeline&legend=bottom-right&v=20260319" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the chart service it pointed to stopped working under GitHub stargazer API restrictions. This replaces the chart and its link with star-history.dera.page, a working alternative that requires no API token. The repository owner is unchanged, so no link 404s were introduced.